### PR TITLE
docs: add bilingual model serving documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,32 @@ jobs:
       - name: Build Docker image
         run: make docker-build
 
+  docs:
+    name: Docs Site
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs/fusioninfer
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: docs/fusioninfer/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check translated content
+        run: npm run check:i18n
+
+      - name: Typecheck docs site
+        run: npm run typecheck
+
+      - name: Build docs site
+        run: npm run build
+

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.11.0
+              image: vllm/vllm-openai:v0.27.1
               args: ["--model", "Qwen/Qwen3-8B"]
               resources:
                 limits:

--- a/docs/fusioninfer/blog/2026-07-25-introducing-fusioninfer.md
+++ b/docs/fusioninfer/blog/2026-07-25-introducing-fusioninfer.md
@@ -2,7 +2,7 @@
 slug: introducing-fusioninfer
 title: "Introducing FusionInfer: A Kubernetes-native Platform for LLM Inference"
 authors: [fusioninfer-team]
-tags: [Kubernetes, LLM inference, platform engineering]
+tags: [kubernetes, llm-inference, platform-engineering]
 description: Meet FusionInfer, a Kubernetes-native platform for declarative LLM inference orchestration.
 ---
 
@@ -12,7 +12,7 @@ FusionInfer brings those responsibilities behind one Kubernetes API.
 
 <!-- truncate -->
 
-## One declarative API
+## One declarative API {#one-declarative-api}
 
 FusionInfer provides an `InferenceService` custom resource for describing an inference topology. A service can combine workload roles, replica counts, multi-node settings, pod templates, and routing configuration in one manifest.
 
@@ -24,7 +24,7 @@ The controller turns that declaration into the Kubernetes resources needed by th
 
 This keeps the user-facing workflow Kubernetes-native while leaving the inference engine inside the workload container.
 
-## Three serving topologies
+## Three serving topologies {#three-serving-topologies}
 
 FusionInfer is designed around three LLM serving patterns:
 
@@ -34,7 +34,7 @@ FusionInfer is designed around three LLM serving patterns:
 
 Each topology uses the same `InferenceService` API, so teams do not need a separate orchestration model for every serving pattern.
 
-## A familiar Kubernetes workflow
+## A familiar Kubernetes workflow {#a-familiar-kubernetes-workflow}
 
 The following shortened example declares a routed, single-node service:
 
@@ -58,7 +58,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.11.0
+              image: vllm/vllm-openai:v0.26.0
               args: ["--model", "Qwen/Qwen3-8B"]
               resources:
                 limits:
@@ -67,7 +67,7 @@ spec:
 
 Users submit the manifest with standard Kubernetes tooling. FusionInfer then reconciles the workload and routing resources represented by the service.
 
-## Inference-aware routing
+## Inference-aware routing {#inference-aware-routing}
 
 Generic load balancing does not account for signals such as prefix reuse, KV-cache pressure, queue depth, or the split between prefill and decode. FusionInfer's `InferenceService` API exposes routing strategies for:
 
@@ -79,10 +79,10 @@ Generic load balancing does not account for signals such as prefix reuse, KV-cac
 
 Advanced users can also provide an `EndpointPickerConfig` when a predefined strategy is not enough.
 
-## A platform, not an inference engine
+## A platform, not an inference engine {#a-platform-not-an-inference-engine}
 
 FusionInfer does not implement model execution. Engines such as vLLM continue to run in the workload containers. FusionInfer focuses on the Kubernetes control plane around those engines, and its current scope is LLM inference rather than general-purpose machine learning workloads.
 
-## Start exploring
+## Start exploring {#start-exploring}
 
 Read the [documentation](/docs/intro) for the architecture and prerequisites, then follow the [deployment guide](/docs/user-guide/deployment) for single-node and multi-node examples.

--- a/docs/fusioninfer/blog/2026-07-25-introducing-fusioninfer.md
+++ b/docs/fusioninfer/blog/2026-07-25-introducing-fusioninfer.md
@@ -58,7 +58,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args: ["--model", "Qwen/Qwen3-8B"]
               resources:
                 limits:

--- a/docs/fusioninfer/blog/tags.yml
+++ b/docs/fusioninfer/blog/tags.yml
@@ -1,0 +1,14 @@
+kubernetes:
+  label: Kubernetes
+  permalink: /kubernetes
+  description: Content about Kubernetes-native orchestration and infrastructure.
+
+llm-inference:
+  label: LLM inference
+  permalink: /llm-inference
+  description: Content about large language model inference and serving.
+
+platform-engineering:
+  label: Platform engineering
+  permalink: /platform-engineering
+  description: Content about building and operating inference platforms.

--- a/docs/fusioninfer/docs/design/core-design.md
+++ b/docs/fusioninfer/docs/design/core-design.md
@@ -53,7 +53,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "Qwen/Qwen3-8B"
@@ -83,7 +83,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "Qwen/Qwen3-8B"
@@ -102,7 +102,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "Qwen/Qwen3-8B"
@@ -136,7 +136,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "deepseek-ai/DeepSeek-R1"
@@ -170,7 +170,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "deepseek-ai/DeepSeek-R1"
@@ -193,7 +193,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "deepseek-ai/DeepSeek-R1"
@@ -472,7 +472,7 @@ spec:
       spec:
         containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args: ["Qwen/Qwen3-8B"]
             ports:
               - containerPort: 8000
@@ -540,7 +540,7 @@ spec:
         schedulerName: volcano
         containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             command: ["/bin/sh", "-c"]
             args:
               - "ray start --head --port=6379 && vllm serve deepseek-ai/DeepSeek-R1 --tensor-parallel-size 32 --distributed-executor-backend ray"
@@ -562,7 +562,7 @@ spec:
         schedulerName: volcano
         containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             command: ["/bin/sh", "-c"]
             args:
               - "ray start --address=$LWS_LEADER_ADDRESS:6379 --block"
@@ -668,7 +668,7 @@ spec:
         schedulerName: volcano
         containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             # ... prefill config
 ---
 # Decode LWS for replica 0
@@ -696,7 +696,7 @@ spec:
         schedulerName: volcano
         containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             # ... decode config
 ```
 

--- a/docs/fusioninfer/docs/design/inference-deployment.md
+++ b/docs/fusioninfer/docs/design/inference-deployment.md
@@ -1,0 +1,456 @@
+---
+title: InferenceDeployment
+description: Bind a Model to a RuntimeProfile and declare replicas, caching, routing, rollout, and status behavior.
+---
+
+## Resource Purpose {#resource-purpose}
+
+`InferenceDeployment` is a Namespaced resource that creates an accessible model inference service. It binds a Base Model, optional LoRAs, and a RuntimeProfile through explicit references, and declares the deployment replica counts, model materialization timing, and Gateway API entry point.
+
+The following example shows a minimal Aggregated topology. Omitting `spec.cache` uses the default `lazy` mode.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-8b-chat
+  namespace: team-a
+spec:
+  modelRef:
+    kind: Model
+    name: qwen3-8b-r1
+  runtimeRef:
+    kind: RuntimeProfile
+    name: vllm-aggregated
+  replicas:
+    aggregated: 1
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+```
+
+## Spec {#spec}
+
+### API Structure {#api-structure}
+
+```go
+type InferenceDeploymentSpec struct {
+    ModelRef   ResourceReference `json:"modelRef"`
+    RuntimeRef ResourceReference `json:"runtimeRef"`
+
+    // +listType=map
+    // +listMapKey=servedName
+    LoRA []LoRABinding `json:"lora,omitempty"`
+
+    // +kubebuilder:default={mode: lazy}
+    // +optional
+    Cache      *CachePolicy      `json:"cache,omitempty"`
+    Replicas   ReplicaSpec       `json:"replicas"`
+    Endpoint   EndpointSpec      `json:"endpoint"`
+}
+
+type LoRABinding struct {
+    ModelRef ResourceReference `json:"modelRef"`
+
+    // +kubebuilder:validation:MinLength=1
+    ServedName string `json:"servedName"`
+}
+
+type ResourceReference struct {
+    Kind string `json:"kind"`
+    Name string `json:"name"`
+}
+
+type CacheMode string
+
+const (
+    CacheModeLazy  CacheMode = "lazy"
+    CacheModeEager CacheMode = "eager"
+)
+
+type CachePolicy struct {
+    Mode CacheMode `json:"mode"`
+}
+
+type ReplicaSpec struct {
+    Aggregated *int32 `json:"aggregated,omitempty"`
+    Prefiller  *int32 `json:"prefiller,omitempty"`
+    Decoder    *int32 `json:"decoder,omitempty"`
+}
+
+type EndpointSpec struct {
+    GatewayRef     GatewayReference     `json:"gatewayRef"`
+    Hostnames      []gatewayv1.Hostname `json:"hostnames,omitempty"`
+    EndpointPicker *EndpointPickerSpec  `json:"endpointPicker,omitempty"`
+}
+
+type EndpointPickerSpec struct {
+    // Reuses the existing v1alpha1 RoutingStrategy type.
+    // +kubebuilder:validation:Enum=prefix-cache;kv-cache-utilization;queue-size
+    Strategy RoutingStrategy `json:"strategy"`
+}
+
+type GatewayReference struct {
+    Name        gatewayv1.ObjectName   `json:"name"`
+    Namespace   *gatewayv1.Namespace   `json:"namespace,omitempty"`
+    SectionName *gatewayv1.SectionName `json:"sectionName,omitempty"`
+}
+```
+
+### Resource References {#resource-references}
+
+`modelRef` and `runtimeRef` use an explicit `kind + name`:
+
+- `modelRef.kind` allows only `Model` or `ClusterModel`.
+- `runtimeRef.kind` allows only `RuntimeProfile` or `ClusterRuntimeProfile`.
+- The API Group is fixed to `fusioninfer.io`, so references do not repeat the `apiGroup`.
+- References do not provide a default Kind, selector, Namespace fallback, or fallback to another resource with the same name.
+
+`modelRef` must reference a Base Model. LoRAs are bound through the separate `spec.lora` list; a LoRA Model cannot be used directly as `modelRef`.
+
+### LoRA Bindings {#lora-bindings}
+
+`spec.lora` can bind multiple LoRA Models to the same Base Model deployment:
+
+```yaml
+lora:
+  - modelRef:
+      kind: Model
+      name: qwen3-8b-finance-lora-r1
+    servedName: finance
+  - modelRef:
+      kind: Model
+      name: qwen3-8b-support-lora-r1
+    servedName: customer-support
+```
+
+Each binding contains two pieces of information:
+
+- `modelRef` must resolve to a LoRA Model that has `spec.lora.baseModelRef`.
+- `servedName` is the model name used to select the LoRA in an OpenAI-compatible request.
+
+After resolving a LoRA, the Controller must confirm that its `baseModelRef` and the Deployment's `modelRef` point to the same Kind, name, and UID. Bindings with the same `servedName` or duplicate `modelRef` values are rejected. The number of bindings cannot exceed the RuntimeProfile's `lora.maxLoadedAdapters`.
+
+The referenced RuntimeProfile must declare `spec.lora`:
+
+- `loadingMode: preload`: The Controller materializes all LoRAs before creating a workload revision and passes the binding manifest to the backend startup integration. Adding, deleting, or replacing a binding creates a new workload revision.
+- `loadingMode: dynamic`: The Controller reconciles loading and unloading against the existing Base Model workload without restarting it. Adding, deleting, or replacing a binding updates only the LoRA binding revision.
+
+In P/D mode, each binding must be loaded into every Prefiller and Decoder logical replica. Through the backend integration, the Controller calls the Pod-local LoRA management endpoint of each logical replica; the backend can have the Leader coordinate loading within the group, or the integration can fan out to all members. A replica counts as Ready only after its Leader and all Workers confirm that the target digest is loaded.
+
+During dynamic loading, Endpoint Picker publishes a `servedName` only after it is Ready on all required roles. When deleting a binding, the Controller first stops publishing the name and waits for in-flight requests to drain before unloading the LoRA. When replacing a LoRA artifact under the same `servedName`, that LoRA name may be temporarily unavailable if the backend does not support atomic replacement; the Base Model and other LoRAs are unaffected.
+
+### Replicas {#replicas}
+
+`replicas` uses the same field combinations as the RuntimeProfile:
+
+- Setting only `aggregated` indicates an Aggregated deployment.
+- Setting both `prefiller` and `decoder` indicates a Prefill/Decode deployment.
+- Each value represents the number of logical replicas for the corresponding role, not the number of Pods.
+- When the RuntimeProfile configures `multinode.nodeCount` for a role, one logical replica expands into one Leader Pod and `nodeCount - 1` Worker Pods.
+
+Changing `replicas` only increases or decreases the number of independently routable logical replicas. It does not change the RuntimeProfile's fixed `multinode.nodeCount`, accelerator resources per Pod, or TP/PP/DP. `replicas` also does not equal the backend's data parallel size: the former creates independent workload groups and serving Endpoints, while the latter is an engine parallelism parameter within a single logical replica.
+
+The Deployment's role combination must exactly match the referenced RuntimeProfile. With an Aggregated Profile, only `replicas.aggregated` can be set; with a P/D Profile, both `replicas.prefiller` and `replicas.decoder` must be set.
+
+### Cache {#cache}
+
+`spec.cache` defaults to `lazy` when omitted. Setting `cache.mode` explicitly selects when the deployment uses the model artifacts:
+
+- `lazy`: After a Pod is scheduled to a node, an injected init container checks the node cache. On a cache miss, it downloads and verifies the model; the inference engine starts only after this completes.
+- `eager`: Before creating new inference workloads, a warm-up Job runs on nodes that satisfy the role's scheduling constraints. New workloads are created only after all required copies have been materialized.
+
+This policy applies to both the Base Model and the artifacts referenced by `spec.lora`. `preload` mode requires the Base Model and all LoRAs to be readable before the engine starts. When a LoRA is added in `dynamic` mode, `eager` warms it on all target nodes first, while `lazy` uses a trusted materializer on the target nodes to materialize it on demand. In either cache mode, the backend loading interface is called only after materialization completes.
+
+For each role, `eager` calculates the warming requirement as logical replica count × effective node count. The effective node count comes from the role's `multinode.nodeCount` and defaults to 1 when unset; the Controller prepares one model cache copy on each distinct node that satisfies the Pod template's scheduling constraints.
+
+Both modes use the same content-addressed node cache and derive an immutable cache key from the normalized source URI, the revision or OCI descriptor digest, and the optional `source.digest`.
+
+`eager` warm-up Jobs do not request or reserve GPUs. If the model is warm but GPUs are unavailable, the workload can remain Pending; a failed new version does not prematurely delete the previous version that is still serving.
+
+`pvc://` sources must also be copied to the immutable node cache first. The engine mounts the cached copy read-only and does not use the mutable source PVC contents directly.
+
+### Endpoint {#endpoint}
+
+`endpoint` is required in v1. The Controller creates Endpoint Picker, InferencePool, and HTTPRoute resources from this field:
+
+- `gatewayRef.name` specifies the Gateway to which the HTTPRoute attaches.
+- When `gatewayRef.namespace` is omitted, it uses the `InferenceDeployment`'s Namespace.
+- `gatewayRef.sectionName` is optional and selects a Gateway listener.
+- `hostnames` is written to the field of the same name in the HTTPRoute and participates only in matching incoming requests.
+
+The `gatewayRef` API Group is fixed to `gateway.networking.k8s.io` and its Kind is fixed to `Gateway`, so only the name and optional Namespace and SectionName are required.
+
+`endpointPicker` applies only to Aggregated deployments:
+
+- It supports `prefix-cache`, `kv-cache-utilization`, and `queue-size`.
+- When omitted, it uses the default strategy configured by the Operator.
+- P/D deployments must omit this field; the Controller automatically generates Prefill and Decode scheduling configuration from `prefiller + decoder`.
+
+The Endpoint Picker image, replica count, and port are managed by Operator configuration and are not part of the RuntimeProfile or InferenceDeployment user interface.
+
+### Scope and References {#scope-and-references}
+
+`InferenceDeployment` exists only in Namespaced form:
+
+- When referencing a `Model` or `RuntimeProfile`, lookup is limited to the Deployment's Namespace.
+- When referencing a `ClusterModel` or `ClusterRuntimeProfile`, lookup is limited to Cluster-scoped objects.
+- Namespaced references cannot specify or access another Namespace.
+- ClusterModel credentials and Namespaced dependencies in a ClusterRuntimeProfile are resolved in the Deployment's Namespace.
+
+Whether a cross-Namespace Gateway accepts the generated HTTPRoute is determined by the Gateway listener's `allowedRoutes`. FusionInfer does not modify the Gateway or try another object with the same name after reference resolution fails.
+
+After a reference is resolved successfully, Status records the target object's Kind, name, UID, and generation. The Base Model and Runtime are stored in `resolvedRefs`, while LoRAs are stored in the corresponding `status.lora[]` entries. Deleting and recreating an object with the same name produces a new UID and is treated as a change to the reference target.
+
+### Defaults and Validation {#defaults-and-validation}
+
+- `modelRef`, `runtimeRef`, `replicas`, and `endpoint` are required.
+- `modelRef.kind`, `modelRef.name`, `runtimeRef.kind`, and `runtimeRef.name` are required.
+- When `lora` is omitted, no LoRA is bound; when present, it must contain at least one entry.
+- Every `lora[].modelRef` and `servedName` is required, and `servedName` must be unique within the list.
+- `lora[].modelRef` values cannot be duplicated.
+- `replicas` can contain only `aggregated`, or it can contain both `prefiller` and `decoder`.
+- Each replica count must be at least 1.
+- When `cache` is omitted, it defaults to `{mode: lazy}`; when set explicitly, `cache.mode` allows only `lazy` or `eager`.
+- `endpoint.gatewayRef.name` is required.
+- `endpoint.endpointPicker.strategy` is allowed only for Aggregated deployments and must be one of the supported strategies.
+- Compatibility between the RuntimeProfile roles and the Deployment replica combination is validated after reference resolution.
+- When `lora` is declared, the RuntimeProfile must support LoRA, and the number of bindings cannot exceed `maxLoadedAdapters`.
+- The Controller must confirm that every binding references a LoRA Model and that its `baseModelRef` and the Deployment's Base Model reference resolve to the same UID.
+- The RuntimeProfile's backend adapter must support the images and entrypoint arguments in the template and must not conflict with the distributed orchestration parameters declared by the template. If unsupported, the Controller does not create new workloads and sets `ReferencesResolved=False`.
+- `InferenceDeployment.spec` can be updated. Changes to the Model, Runtime, cache mode, or Endpoint Picker strategy create a new revision pending promotion. Whether a LoRA change rebuilds the workload is determined by the RuntimeProfile's `loadingMode`.
+
+Constraints that do not require reading other objects are validated by CRD OpenAPI, CEL, or Admission. Whether references exist, roles match, Secret/PVC resources are available, and the Gateway accepts the Route is reconciled by the Controller and reported through Conditions, so resources can be created in any order.
+
+## Status {#status}
+
+`InferenceDeployment.status` summarizes reference resolution, model materialization, workload, routing, and rollout status:
+
+```go
+type InferenceDeploymentStatus struct {
+    ObservedGeneration int64                               `json:"observedGeneration,omitempty"`
+    ResolvedRefs       *ResolvedReferences                 `json:"resolvedRefs,omitempty"`
+    ModelCache         *ModelCacheStatus                   `json:"modelCache,omitempty"`
+
+    // +listType=map
+    // +listMapKey=servedName
+    LoRA               []LoRABindingStatus                 `json:"lora,omitempty"`
+
+    Components         map[string]InferenceComponentStatus `json:"components,omitempty"`
+    Endpoint           *EndpointStatus                     `json:"endpoint,omitempty"`
+    ActiveRevision     *DeploymentRevisionStatus           `json:"activeRevision,omitempty"`
+    PendingRevision    *DeploymentRevisionStatus           `json:"pendingRevision,omitempty"`
+
+    // +listType=map
+    // +listMapKey=type
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+type ResolvedReferenceStatus struct {
+    Kind       string    `json:"kind"`
+    Name       string    `json:"name"`
+    UID        types.UID `json:"uid"`
+    Generation int64     `json:"generation"`
+    Digest     string    `json:"digest,omitempty"`
+}
+
+type ModelCacheStatus struct {
+    Mode          CacheMode `json:"mode"`
+    Digest        string    `json:"digest,omitempty"`
+    DesiredCopies int32     `json:"desiredCopies,omitempty"`
+    ReadyCopies   int32     `json:"readyCopies,omitempty"`
+}
+
+type InferenceComponentStatus struct {
+    DesiredReplicas int32 `json:"desiredReplicas"`
+    ReadyReplicas   int32 `json:"readyReplicas"`
+    NodesPerReplica int32 `json:"nodesPerReplica"`
+    ReadyPods       int32 `json:"readyPods"`
+}
+
+type LoRABindingStatus struct {
+    ServedName string                              `json:"servedName"`
+    Model      *ResolvedReferenceStatus            `json:"model,omitempty"`
+    Cache      *ModelCacheStatus                   `json:"cache,omitempty"`
+    Components map[string]LoRAComponentStatus      `json:"components,omitempty"`
+
+    // +listType=map
+    // +listMapKey=type
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+type LoRAComponentStatus struct {
+    DesiredReplicas int32 `json:"desiredReplicas"`
+    ReadyReplicas   int32 `json:"readyReplicas"`
+}
+```
+
+`components` uses the stable `endpointPicker`, `aggregated`, `prefiller`, and `decoder` keys. `nodesPerReplica` records the effective `multinode.nodeCount` from the RuntimeProfile and defaults to 1 when unset; `readyReplicas` counts a logical replica only when all of its `nodesPerReplica` Pods are Ready. `ModelCacheStatus.desiredCopies` and `readyCopies` record the required and completed distinct-node cache copies for the current revision, respectively. `activeRevision` identifies the version currently receiving traffic; `pendingRevision` identifies the new version being materialized, scheduled, or awaiting promotion.
+
+`status.lora` uses `servedName` as the list key and summarizes the resolved Model, cache copies, and loading progress for each role for every binding. It does not expose backend management endpoint addresses or per-Pod error bodies. In `preload` mode, Ready status advances with promotion of the workload revision; in `dynamic` mode, it directly reflects loading status in the current active revision.
+
+Conditions use the standard `metav1.Condition` without adding a single `phase` field:
+
+- `ReferencesResolved`: The references to the Base Model, all LoRA Models, and the RuntimeProfile have been resolved and passed consumer-side validation.
+- `ModelMaterialized`: The Base Model cache copies required by the current revision are available; LoRA materialization status is recorded in each binding.
+- `LoRAReady`: All declared LoRAs have been resolved, materialized, and loaded into every required logical replica; it is `True` when there are no LoRAs.
+- `WorkloadsReady`: The desired logical replicas for all roles are Ready; a multinode logical replica requires the Leader and all Worker Pods to be Ready.
+- `RouteReady`: The Service, InferencePool, Endpoint Picker, and HTTPRoute are ready.
+- `Available`: The current active revision can accept requests.
+- `Progressing`: Warming, creation, scaling, or updates are still in progress.
+- `Degraded`: Reconciliation failed and requires intervention from the user or platform administrator.
+
+In dynamic mode, a failure in one LoRA sets `LoRAReady=False`, but `Available` can remain `True` as long as the active Base Model can still serve requests. The failed served name is not published to Endpoint Picker.
+
+Every Condition must include `observedGeneration`, a stable `reason`, and an actionable `message`. The following example shows the status of a ready Aggregated deployment:
+
+```yaml
+status:
+  observedGeneration: 2
+  resolvedRefs:
+    model:
+      kind: ClusterModel
+      name: qwen3-8b-r1
+      uid: 8bb42ec6-95a5-4dc8-904f-6a69ee9bb8c8
+      generation: 1
+      digest: sha256:7f3c9a1e4b2d8f605a7c3e9d1b4f2860c5a8e2d7f1b3096c4e8a5d2f7b1c903e
+    runtime:
+      kind: ClusterRuntimeProfile
+      name: vllm-aggregated-h100-r1
+      uid: f42e664a-bf65-4690-8e0a-93568e854e3d
+      generation: 1
+  modelCache:
+    mode: eager
+    digest: sha256:7f3c9a1e4b2d8f605a7c3e9d1b4f2860c5a8e2d7f1b3096c4e8a5d2f7b1c903e
+    desiredCopies: 2
+    readyCopies: 2
+  components:
+    aggregated:
+      desiredReplicas: 2
+      readyReplicas: 2
+      nodesPerReplica: 1
+      readyPods: 2
+    endpointPicker:
+      desiredReplicas: 1
+      readyReplicas: 1
+      nodesPerReplica: 1
+      readyPods: 1
+  endpoint:
+    routeRef:
+      name: qwen3-8b-chat
+      namespace: team-a
+    addresses:
+      - hostname: qwen3-8b.example.com
+        url: https://qwen3-8b.example.com
+  conditions:
+    - type: Available
+      status: "True"
+      observedGeneration: 2
+      reason: Ready
+      message: The active revision is ready to serve requests.
+```
+
+## Examples {#examples}
+
+### Namespaced Aggregated: Default lazy cache {#namespaced-aggregated-default-lazy-cache}
+
+Both the Model and RuntimeProfile are resolved from the `team-a` Namespace. This deployment omits `spec.cache` to use the default `lazy` mode, creates two Aggregated logical replicas, and uses the prefix-cache Endpoint Picker.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: llama-3-8b-chat
+  namespace: team-a
+spec:
+  modelRef:
+    kind: Model
+    name: llama-3-8b-r1
+  runtimeRef:
+    kind: RuntimeProfile
+    name: vllm-aggregated-a10-r1
+  replicas:
+    aggregated: 2
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+      sectionName: https
+    hostnames:
+      - llama-3-8b.example.com
+    endpointPicker:
+      strategy: prefix-cache
+```
+
+### Cluster Prefill/Decode: eager cache {#cluster-prefilldecode-eager-cache}
+
+The Model and RuntimeProfile use Cluster-scoped objects. The Controller warms the model before starting two Prefiller and four Decoder logical replicas; the P/D deployment does not declare `endpointPicker`.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-32b-chat
+  namespace: team-b
+spec:
+  modelRef:
+    kind: ClusterModel
+    name: qwen3-32b-r1
+  runtimeRef:
+    kind: ClusterRuntimeProfile
+    name: vllm-pd-h100-r1
+  cache:
+    mode: eager
+  replicas:
+    prefiller: 2
+    decoder: 4
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+      sectionName: https
+    hostnames:
+      - qwen3-32b.example.com
+```
+
+### Namespaced Aggregated: Multiple dynamic LoRAs {#namespaced-aggregated-multiple-dynamic-loras}
+
+This deployment uses a RuntimeProfile that supports dynamic LoRA. The two LoRAs use `finance` and `customer-support` as their model names in requests.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-8b-chat
+  namespace: team-a
+spec:
+  modelRef:
+    kind: Model
+    name: qwen3-8b-r1
+  runtimeRef:
+    kind: RuntimeProfile
+    name: vllm-aggregated-lora-dynamic-r1
+  lora:
+    - modelRef:
+        kind: Model
+        name: qwen3-8b-finance-lora-r1
+      servedName: finance
+    - modelRef:
+        kind: Model
+        name: qwen3-8b-support-lora-r1
+      servedName: customer-support
+  cache:
+    mode: eager
+  replicas:
+    aggregated: 2
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+      sectionName: https
+    hostnames:
+      - qwen3-8b.example.com
+    endpointPicker:
+      strategy: prefix-cache
+```

--- a/docs/fusioninfer/docs/design/model-serving.md
+++ b/docs/fusioninfer/docs/design/model-serving.md
@@ -102,7 +102,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH) # The Controller injects the model path from the node cache
             ports:

--- a/docs/fusioninfer/docs/design/model-serving.md
+++ b/docs/fusioninfer/docs/design/model-serving.md
@@ -1,0 +1,192 @@
+---
+title: Architecture
+---
+
+FusionInfer separates model inference into three conceptual resources with distinct responsibilities:
+
+- [`Model` / `ClusterModel`](./model.md) declares the source and immutable version of a model artifact.
+- [`RuntimeProfile` / `ClusterRuntimeProfile`](./runtime-profile.md) defines how each replica runs.
+- [`InferenceDeployment`](./inference-deployment.md) binds a Model to a RuntimeProfile and declares replica counts, cache policy, and access endpoint.
+
+FusionInfer uses these three resources to create and continuously manage model inference services. This includes downloading and caching models, orchestrating inference workloads, configuring traffic routing, and exposing inference endpoints to users. The same Model or RuntimeProfile can be reused by multiple InferenceDeployment resources; each InferenceDeployment independently declares its replica counts, cache mode, and traffic entry point.
+
+The following single-node Prefill/Decode disaggregation example shows how the three core resources produce Pod workloads and how requests enter the inference service through a Gateway and EPP.
+
+```mermaid
+flowchart LR
+    subgraph Resources["Core FusionInfer resources"]
+        direction TB
+        Model["Model / ClusterModel<br/>Declares model source and version"]
+        Runtime["RuntimeProfile / ClusterRuntimeProfile<br/>Declares P/D topology, image, and Pod template"]
+        Deployment["InferenceDeployment<br/>References Model and RuntimeProfile<br/>Declares replicas and endpoint"]
+
+        Deployment -->|"References through modelRef"| Model
+        Deployment -->|"References through runtimeRef"| Runtime
+    end
+
+    Controller["InferenceDeployment Controller"]
+    Model -->|"Model source and version"| Controller
+    Runtime -->|"P/D topology and Pod template"| Controller
+    Deployment -->|"Replica counts and traffic entry point"| Controller
+
+    Client["Client"]
+
+    subgraph Serving["Single-node P/D inference service"]
+        direction TB
+
+        subgraph Routing["Request entry point and routing"]
+            direction LR
+            Gateway["Gateway"] --> Route["HTTPRoute"]
+            Route --> Pool["InferencePool"]
+            Pool --> EPP["EPP"]
+        end
+
+        subgraph Pods["Single-node P/D workloads"]
+            direction LR
+            Disaggregated["DisaggregatedSet"]
+            Prefill["Prefill Pod(s)"]
+            Decode["Decode Pod(s)"]
+
+            Disaggregated --> Prefill
+            Disaggregated --> Decode
+            Prefill -->|"KV Cache"| Decode
+        end
+
+        EPP --> Prefill
+        EPP --> Decode
+    end
+
+    Client --> Gateway
+    Controller -.->|"Create P/D workloads"| Disaggregated
+    Controller -.->|"Download and mount Model"| Prefill
+    Controller -.->|"Download and mount Model"| Decode
+    Controller -.->|"Create"| Route
+    Controller -.->|"Create"| Pool
+    Controller -.->|"Deploy"| EPP
+```
+
+## Core Resources {#core-resources}
+
+### Model {#model}
+
+`Model` / `ClusterModel` declare reusable, immutable model artifacts. The following example declares a Hugging Face model in the `team-a` Namespace and pins its version with a full commit SHA.
+
+```yaml {8}
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-r1
+  namespace: team-a
+spec:
+  source:
+    uri: hf://Qwen/Qwen3-8B # Model artifact source
+    revision: 0123456789abcdef0123456789abcdef01234567
+```
+
+For the detailed design, see [Model and ClusterModel](./model.md).
+
+### RuntimeProfile {#runtimeprofile}
+
+`RuntimeProfile` / `ClusterRuntimeProfile` define how a single logical replica runs, including Aggregated, Prefill/Decode disaggregation, and multi-node execution. The following example declares a single-node Aggregated vLLM runtime template that uses one GPU.
+
+```yaml {15,28}
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated-r1
+  namespace: team-a
+spec:
+  backend: vllm
+  aggregated:
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH) # The Controller injects the model path from the node cache
+            ports:
+              - name: http
+                containerPort: 8000
+            readinessProbe:
+              httpGet:
+                path: /health
+                port: http
+            resources:
+              requests:
+                cpu: "4"
+                memory: 16Gi
+              limits:
+                nvidia.com/gpu: "1" # One GPU per logical replica
+```
+
+For the detailed design, see [RuntimeProfile and ClusterRuntimeProfile](./runtime-profile.md).
+
+### InferenceDeployment {#inferencedeployment}
+
+`InferenceDeployment` binds a Model to a RuntimeProfile and serves as the entry point for the Controller to create a model-serving instance. The following example references the two preceding Namespaced objects, creates two Aggregated logical replicas, and publishes an OpenAI-compatible endpoint through a Gateway in the same Namespace.
+
+```yaml {7,10,14-15}
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-8b-chat
+  namespace: team-a
+spec:
+  modelRef: # References Model
+    kind: Model
+    name: qwen3-8b-r1
+  runtimeRef: # References RuntimeProfile
+    kind: RuntimeProfile
+    name: vllm-aggregated-r1
+  replicas:
+    aggregated: 2 # Declares two logical replicas
+  endpoint: # Declares the inference service entry point
+    gatewayRef:
+      name: inference-gateway
+    hostnames:
+      - qwen3-8b.example.com
+    endpointPicker:
+      strategy: prefix-cache
+```
+
+For the detailed design, see [InferenceDeployment](./inference-deployment.md).
+
+## Routing {#routing}
+
+After an inference service is deployed, its inference endpoint needs to be exposed to users or Agents. FusionInfer integrates with the [Gateway API Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/) to generate an HTTPRoute, InferencePool, and EPP from `InferenceDeployment.spec.endpoint`, and attaches the HTTPRoute to an existing Gateway. The EPP routes requests to available inference Pods according to the configured strategy.
+
+For the detailed design, see [InferenceDeployment Endpoint](./inference-deployment.md#endpoint).
+
+## Reconciliation Flow {#reconciliation-flow}
+
+The Controller reconciles `InferenceDeployment` in the following stages:
+
+- **Resolve resources**: Read the Model and RuntimeProfile referenced by `modelRef` and `runtimeRef`.
+- **Prepare the model**: Download the model according to the cache policy and ensure that the model cache is available.
+- **Orchestrate workloads**: Create or update LeaderWorkerSet / DisaggregatedSet and wait for the workloads to become ready.
+- **Configure routing**: Create or update the HTTPRoute, InferencePool, and EPP.
+- **Update status**: Write the reconciliation result to `InferenceDeployment.status`.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant API as Kubernetes API
+    participant Controller as InferenceDeployment Controller
+    participant Resources as Model / RuntimeProfile
+    participant Cache as Model Cache
+    participant Workload as LeaderWorkerSet / DisaggregatedSet
+    participant Routing as HTTPRoute / InferencePool / EPP
+
+    User->>API: Create or update InferenceDeployment
+    API-->>Controller: generation changes
+    Controller->>Resources: Resolve modelRef and runtimeRef
+    Resources-->>Controller: Return model and runtime configuration
+    Controller->>Cache: Download and cache model in lazy or eager mode
+    Cache-->>Controller: Model cache ready
+    Controller->>Workload: Create or update inference workload
+    Workload-->>Controller: Inference workload ready
+    Controller->>Routing: Create or update routing resources
+    Routing-->>Controller: Routing ready
+    Controller->>API: Update InferenceDeployment status
+```

--- a/docs/fusioninfer/docs/design/model.md
+++ b/docs/fusioninfer/docs/design/model.md
@@ -1,0 +1,219 @@
+---
+title: Model and ClusterModel
+description: Define namespaced or cluster-scoped immutable model artifacts and optional LoRA adapter bindings.
+---
+
+## Resource scope {#resource-scope}
+
+`Model` and `ClusterModel` declare the source of a model artifact and its version identifier:
+
+- `Model` is a Namespaced resource for models within a Namespace.
+- `ClusterModel` is a cluster-scoped resource for models shared across Namespaces.
+
+Both Kinds use the same `ModelSpec`. Setting only `spec.source` represents a Base Model; setting both `spec.source` and `spec.lora.baseModelRef` represents a LoRA artifact.
+
+The following example is a minimal Namespaced Base Model:
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-r1
+  namespace: team-a
+spec:
+  source:
+    uri: hf://Qwen/Qwen3-8B
+    revision: 0123456789abcdef0123456789abcdef01234567
+```
+
+## Spec {#spec}
+
+### API structure {#api-structure}
+
+`Model` and `ClusterModel` share the following Go API:
+
+```go
+type ModelSpec struct {
+    Source ModelSource      `json:"source"`
+    LoRA   *LoRAArtifactSpec `json:"lora,omitempty"`
+}
+
+type LoRAArtifactSpec struct {
+    BaseModelRef ModelReference `json:"baseModelRef"`
+}
+
+type ModelReference struct {
+    Kind string `json:"kind"`
+    Name string `json:"name"`
+}
+
+type ModelSource struct {
+    URI            string                        `json:"uri"`
+    Revision       string                        `json:"revision,omitempty"`
+    Digest         string                        `json:"digest,omitempty"`
+    CredentialsRef *corev1.LocalObjectReference `json:"credentialsRef,omitempty"`
+}
+```
+
+Omitting `lora` represents a Base Model; including it represents a LoRA. Whether `revision` and `digest` are required depends on the `uri` scheme.
+
+### Scope and references {#scope-and-references}
+
+All references belong to the `fusioninfer.io` API Group and contain only `kind` and `name`:
+
+- A Namespaced LoRA `Model` can reference a `Model` in the same Namespace or a cluster-scoped `ClusterModel`.
+- A cluster-scoped LoRA `ClusterModel` can reference only a `ClusterModel`.
+- `baseModelRef` must point to a Base Model, not another LoRA.
+
+References do not provide a default Kind, Namespace fallback, or fallback to a resource with the same name.
+
+### Model sources {#model-sources}
+
+`source.uri` is required. v1 supports the following sources:
+
+- `hf://<repository>`: `revision` is required and must be a full commit SHA; `digest` is optional.
+- `s3://<bucket>/<prefix>`: `digest` is required.
+- `oci://<artifact>@sha256:<digest>`: the URI must include the descriptor digest; `source.digest` is optional.
+- `pvc://<claim>/<subpath>`: permitted only for a Namespaced `Model`; `digest` is required, and `credentialsRef` is not allowed.
+
+`source.digest` uses the format `sha256:<64 lowercase hexadecimal characters>`. The URI scheme must be lowercase. Queries, fragments, and `.` or `..` path segments are not allowed.
+
+### Credentials contract {#credentials-contract}
+
+`source.credentialsRef` contains only a Secret name; a Namespace cannot be specified. When omitted, the platform-configured workload identity or anonymous access is used.
+
+- `hf://`: accepts an `Opaque` Secret that must contain `HF_TOKEN`.
+- `s3://`: accepts an `Opaque` Secret, uses standard AWS SDK key names, and supports both AWS S3 and S3-compatible storage.
+- `oci://`: accepts a `kubernetes.io/dockerconfigjson` Secret that must contain `.dockerconfigjson`.
+- `pvc://`: does not allow `credentialsRef`.
+
+- Namespaced `Model`: the Secret is resolved in the Model's Namespace.
+- `ClusterModel`: a Secret with the same name is resolved independently in the Namespace of each `InferenceDeployment` that consumes it. Different teams can provide their own credentials; the cluster-scoped object does not read Secrets across Namespaces or create a single global authentication state.
+
+### LoRA artifact semantics {#lora-artifact-semantics}
+
+A LoRA Model uses `source` to declare its adapter files and `lora.baseModelRef` to declare the corresponding Base Model. `baseModelRef` must be an explicit `kind + name` reference. v1 does not allow a LoRA to reference another LoRA.
+
+A LoRA Model is bound to an inference service through `InferenceDeployment.spec.lora[]`. The artifact's `baseModelRef` represents a compatibility constraint, while the Deployment's `modelRef` represents the Base Model that actually runs. The Controller loads the LoRA only when both references resolve to the same Kind, name, and UID. The consuming InferenceDeployment and RuntimeProfile manage the loading mode, target logical replicas, and per-role status.
+
+### Defaults and validation {#defaults-and-validation}
+
+- `spec.source` is required.
+- `revision`, `digest`, and `credentialsRef` must satisfy the constraints for the corresponding URI scheme.
+- When `lora` is present, `baseModelRef.kind` and `baseModelRef.name` are required.
+- `ClusterModel` does not allow `pvc://`.
+- A cluster-scoped LoRA cannot reference a Namespaced `Model`.
+- `Model.spec` and `ClusterModel.spec` are immutable in v1. Changing the source, version, credentials, or `baseModelRef` requires creating a new object.
+
+## Status {#status}
+
+`Model` and `ClusterModel` do not provide a status subresource. The existence of a Model object indicates only that its declaration is valid; it does not indicate that the model has been downloaded or loaded.
+
+## Examples {#examples}
+
+### Model: Hugging Face Base Model {#model-hugging-face-base-model}
+
+This object resides in `team-a` and pins the repository version with a full HF commit SHA. `huggingface-token` is resolved in the same Namespace.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-hf-r1
+  namespace: team-a
+spec:
+  source:
+    uri: hf://Qwen/Qwen3-8B
+    revision: 0123456789abcdef0123456789abcdef01234567
+    credentialsRef:
+      name: huggingface-token
+```
+
+### Model: PVC Base Model {#model-pvc-base-model}
+
+This object and the `qwen3-weights` PVC both reside in `team-a`. `digest` verifies the model content in the PVC.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-pvc-r1
+  namespace: team-a
+spec:
+  source:
+    uri: pvc://qwen3-weights/models/qwen3-8b
+    digest: sha256:7f3c9a1e4b2d8f605a7c3e9d1b4f2860c5a8e2d7f1b3096c4e8a5d2f7b1c903e
+```
+
+### Model: S3 Base Model {#model-s3-base-model}
+
+This object reads model files from S3-compatible storage and uses `digest` to verify the materialized content.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-s3-r1
+  namespace: team-a
+spec:
+  source:
+    uri: s3://team-a-models/base/qwen3-8b-r1
+    digest: sha256:4a7d1ed414474e4033ac29ccb8653d9b8f9f45278a28a74cc2d8f7f31e4b6c90
+    credentialsRef:
+      name: s3-model-reader
+```
+
+### Model: OCI Base Model {#model-oci-base-model}
+
+The descriptor digest in the OCI URI pins the artifact version. Registry credentials are provided through a `kubernetes.io/dockerconfigjson` Secret.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-oci-r1
+  namespace: team-a
+spec:
+  source:
+    uri: oci://registry.example.com/models/qwen3-8b@sha256:9d2e6b4a8f1c30573a7e9c2d5b608f14e1d4a7c3096b2f855c8e1a6d4f703b29
+    credentialsRef:
+      name: model-registry-credentials
+```
+
+### Model: LoRA {#model-lora}
+
+This LoRA resides in `team-a`. Its adapter files come from S3, and `baseModelRef` explicitly references a Base Model in the same Namespace.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-finance-lora-r1
+  namespace: team-a
+spec:
+  source:
+    uri: s3://team-a-models/adapters/qwen3-8b-finance-lora-r1
+    digest: sha256:c14a8d6f2e905b378f4c1a7d3e6b2095d2f8a4c7091e5b636a3d9f2e8c1b7045
+    credentialsRef:
+      name: s3-model-reader
+  lora:
+    baseModelRef:
+      kind: Model
+      name: qwen3-8b-hf-r1
+```
+
+### ClusterModel: Shared Base Model {#clustermodel-shared-base-model}
+
+ClusterModel has the same fields as Model but no Namespace. This regular Base Model can be explicitly referenced by InferenceDeployments in multiple Namespaces.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: ClusterModel
+metadata:
+  name: qwen3-14b-shared-r1
+spec:
+  source:
+    uri: hf://Qwen/Qwen3-14B
+    revision: 89abcdef0123456789abcdef0123456789abcdef
+```
+

--- a/docs/fusioninfer/docs/design/router.md
+++ b/docs/fusioninfer/docs/design/router.md
@@ -61,7 +61,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - --model=Qwen/Qwen2.5-7B-Instruct
 ```
@@ -95,7 +95,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - --model=/models/llama-70b
 ```
@@ -130,7 +130,7 @@ spec:
         spec:
           containers:
             - name: prefill
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - --model=meta-llama/Llama-3-70B-Instruct
                 - --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
@@ -141,7 +141,7 @@ spec:
         spec:
           containers:
             - name: decode
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - --model=meta-llama/Llama-3-70B-Instruct
                 - --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
@@ -235,7 +235,7 @@ spec:
         spec:
           containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
             - --model=meta-llama/Llama-3-8B-Instruct
 ```
@@ -431,7 +431,7 @@ spec:
         spec:
           containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
             - --model=meta-llama/Llama-3-8B-Instruct
 ```
@@ -464,7 +464,7 @@ spec:
         spec:
           containers:
             - name: prefill
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - --model=meta-llama/Llama-3-70B-Instruct
                 - --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
@@ -475,7 +475,7 @@ spec:
         spec:
           containers:
             - name: decode
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - --model=meta-llama/Llama-3-70B-Instruct
                 - --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'

--- a/docs/fusioninfer/docs/design/runtime-profile.md
+++ b/docs/fusioninfer/docs/design/runtime-profile.md
@@ -25,7 +25,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
             ports:
@@ -179,7 +179,7 @@ Runtime commands should read the Model through `$(FUSION_MODEL_PATH)` rather tha
 
 When LoRA bindings are declared, the Operator also mounts the current Deployment's adapter projection read-only at `/adapters` and generates `/var/run/fusioninfer/lora/adapters.json`. The Manifest uses an internal binding key to map `servedName`, the resolved Model UID, the digest, and the in-container path; paths do not directly use the user-provided served name. The engine container can see only the LoRAs bound to the current Deployment and cannot browse the node cache root.
 
-Inference images in production must be pinned by OCI digest. For readability, the following examples use the official versioned image `vllm/vllm-openai:v0.26.0`; replace it with the corresponding digest-pinned image when deploying.
+Inference images in production must be pinned by OCI digest. For readability, the following examples use the official versioned image `vllm/vllm-openai:v0.27.1`; replace it with the corresponding digest-pinned image when deploying.
 
 ### Scope and References {#scope-and-references}
 
@@ -236,7 +236,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
             ports:
@@ -272,7 +272,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --kv-transfer-config
@@ -290,7 +290,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --kv-transfer-config
@@ -324,7 +324,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --port
@@ -367,7 +367,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --enable-lora

--- a/docs/fusioninfer/docs/design/runtime-profile.md
+++ b/docs/fusioninfer/docs/design/runtime-profile.md
@@ -1,0 +1,386 @@
+---
+title: RuntimeProfile and ClusterRuntimeProfile
+description: Define reusable runtime templates for aggregated, Prefill/Decode-disaggregated, and multi-node inference.
+---
+
+## Resource Definition {#resource-definition}
+
+`RuntimeProfile` and `ClusterRuntimeProfile` declare reusable inference runtime templates, including the backend, inference image, startup arguments, LoRA loading capabilities, Pod topology, and Aggregated or Prefill/Decode roles:
+
+- `RuntimeProfile` is a namespaced resource that can be reused within a Namespace.
+- `ClusterRuntimeProfile` is a cluster-scoped resource that can be shared across Namespaces.
+
+Both Kinds use the same `RuntimeProfileSpec`. A Profile describes one logical replica per role; it neither specifies deployment replica counts nor binds to a specific Model. The following example shows a minimal Aggregated structure:
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated
+  namespace: team-a
+spec:
+  backend: vllm
+  aggregated:
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+            ports:
+              - name: http
+                containerPort: 8000
+```
+
+## Spec {#spec}
+
+### API Structure {#api-structure}
+
+`RuntimeProfile` and `ClusterRuntimeProfile` share the following Go interfaces:
+
+```go
+// +kubebuilder:validation:Enum=vllm;sglang;trtllm
+type RuntimeBackend string
+
+const (
+    RuntimeBackendVLLM   RuntimeBackend = "vllm"
+    RuntimeBackendSGLang RuntimeBackend = "sglang"
+    RuntimeBackendTRTLLM RuntimeBackend = "trtllm"
+)
+
+type RuntimeProfileSpec struct {
+    Backend    RuntimeBackend        `json:"backend"`
+    LoRA       *RuntimeLoRASpec       `json:"lora,omitempty"`
+    Aggregated *RuntimeComponentSpec `json:"aggregated,omitempty"`
+    Prefiller  *RuntimeComponentSpec `json:"prefiller,omitempty"`
+    Decoder    *RuntimeComponentSpec `json:"decoder,omitempty"`
+}
+
+// +kubebuilder:validation:Enum=preload;dynamic
+type LoRALoadingMode string
+
+const (
+    LoRALoadingModePreload LoRALoadingMode = "preload"
+    LoRALoadingModeDynamic LoRALoadingMode = "dynamic"
+)
+
+type RuntimeLoRASpec struct {
+    LoadingMode LoRALoadingMode `json:"loadingMode"`
+
+    // Control-plane limit for one InferenceDeployment.
+    // +kubebuilder:validation:Minimum=1
+    MaxLoadedAdapters int32 `json:"maxLoadedAdapters"`
+}
+
+type RuntimeComponentSpec struct {
+    // Decoded and validated as corev1.PodTemplateSpec.
+    // +kubebuilder:pruning:PreserveUnknownFields
+    PodTemplate runtime.RawExtension `json:"podTemplate"`
+
+    Multinode *MultinodeSpec `json:"multinode,omitempty"`
+}
+
+type MultinodeSpec struct {
+    // +kubebuilder:validation:Minimum=2
+    NodeCount int32 `json:"nodeCount"`
+}
+```
+
+`podTemplate` uses `runtime.RawExtension` to avoid expanding the complete Kubernetes Pod schema again in the CRD. Admission and Controller must strictly decode it as the currently supported `corev1.PodTemplateSpec`.
+
+### Role Fields {#role-fields}
+
+The valid role field combinations are:
+
+- Setting only `aggregated` selects Aggregated inference.
+- Setting both `prefiller` and `decoder` selects Prefill/Decode disaggregation.
+- `aggregated` cannot coexist with `prefiller` or `decoder`.
+- `prefiller` and `decoder` must appear together.
+
+Each role uses the same `RuntimeComponentSpec`:
+
+- When `multinode` is not set, `podTemplate` represents one complete single-node logical replica.
+- When `multinode` is set, `nodeCount` specifies the total number of nodes used by each logical replica, including one Leader and `nodeCount - 1` Workers.
+- The Leader and Workers are all derived from the same `podTemplate` and must be placed on different Kubernetes Nodes.
+- A single-node, multi-GPU engine should not set `multinode`; it should request multiple GPUs in one Pod instead.
+
+For example, `multinode.nodeCount: 4` means that one logical replica consists of one Leader Pod and three Worker Pods. If the corresponding `InferenceDeployment` sets `replicas.aggregated: 2`, the Controller creates two such logical replicas: two Leader Pods and six Worker Pods, for a total of eight Pods.
+
+### Distributed Backend Execution {#distributed-backend-execution}
+
+`backend` is required and supports `vllm`, `sglang`, and `trtllm`. It selects only the engine adapter; the role field combination still determines whether the mode is Aggregated or P/D. All roles in the same RuntimeProfile use the same backend.
+
+When `multinode` is set, the Controller generates the startup configuration according to the backend and the Pod's role within the logical replica:
+
+- The RuntimeProfile author declares the image, engine parallelism parameters such as TP/PP/DP, resources, and scheduling constraints once, rather than maintaining separate Leader and Worker templates.
+- `multinode.nodeCount`, the accelerator resources for each Pod, and the engine parallelism parameters are fixed in the RuntimeProfile.
+- The Leader establishes the distributed runtime environment and starts the inference service; each Worker only joins the logical replica's distributed runtime environment.
+- The backend adapter may wrap or rewrite the `command` and `args` of the `engine` container in the generated Pod, but only to inject Leader/Worker orchestration differences such as the multiprocessing executor, address, rank, and `nnodes`.
+- The adapter does not derive or modify the TP/PP/DP declared by the RuntimeProfile based on `nodeCount`; these engine parallelism parameters remain unchanged across all logical replicas.
+- The adapter handles only the differences required for distributed startup; user-declared environment variables, resources, volumes, probes, and scheduling constraints continue to apply to every Pod.
+- The Controller does not infer the backend from the image name or arbitrary command strings.
+
+Multinode vLLM always uses the multiprocessing executor. The backend adapter injects `--distributed-executor-backend mp` and the group startup arguments. SGLang uses its native distributed launcher. For Leader/Worker commands and managed parameters, see [Workload Orchestration: Distributed Backend Execution](./workload-orchestration.md#backend-distributed-execution).
+
+The supported image contract, entrypoint forms, and adapter-reserved orchestration parameters for each backend must be documented and tested for every Operator version. A RuntimeProfile cannot predeclare the executor, address, rank, `nnodes`, or headless parameters managed by the adapter. If a conflict occurs or a custom entrypoint cannot be handled, the Controller rejects creation of a new workload when it consumes the RuntimeProfile. The adapter recognizes only the limited parameters defined by the versioned contract; it does not parse arbitrary CLI commands or shell scripts, nor does it validate the mathematical compatibility of the Model with TP/PP/DP. The Profile author is responsible for validating these parameters.
+
+### LoRA Loading Capabilities {#lora-loading-capabilities}
+
+`spec.lora` declares whether the Profile can consume `InferenceDeployment.spec.lora` and fixes the LoRA loading lifecycle:
+
+- When `lora` is omitted, the Profile does not accept LoRA bindings.
+- `loadingMode: preload` materializes and mounts all LoRAs before the engine starts. A change to the binding set produces a new workload revision.
+- `loadingMode: dynamic` loads or unloads LoRAs after the Base Model workload is running and does not restart the Base Model when the binding set changes.
+- `maxLoadedAdapters` limits the number of LoRAs that one InferenceDeployment can bind at the same time.
+
+`maxLoadedAdapters` is a control-plane limit across backends. It does not replace the engine's own GPU memory, CPU cache, maximum LoRA rank, or batch concurrency settings. The Profile author continues to fix these backend-specific parameters in `podTemplate`; the LoRA integration for the corresponding backend validates that known parameters are compatible with the control-plane limit without modifying TP/PP/DP.
+
+The LoRA loading configuration is defined at the top level of the Profile, so Aggregated, Prefiller, and Decoder use the same mode. A P/D deployment must load every LoRA into all routable logical replicas of both the Prefiller and Decoder; it cannot select different loading modes for the two roles.
+
+In dynamic mode, the `InferenceDeployment` Controller calls a Pod-local LoRA management endpoint through the backend integration built into the Operator. The Controller is the only Reconciler and owns the desired bindings, retries, and status; the management endpoint performs only idempotent load, unload, and list operations. If the backend already provides a management interface that satisfies the contract, the Operator uses it directly. Otherwise, the Operator may inject a thin stateless proxy as a backend-specific implementation detail instead of running a second control loop. The management port is not added to the inference Service, InferencePool, or HTTPRoute.
+
+Multinode dynamic loading operates at the logical replica level. Depending on the engine's capabilities, the backend integration calls the Leader coordination interface or performs a controlled fan-out to all members of the logical replica. The logical replica is considered Ready only after the Leader and every Worker confirm that the target digest is loaded. Member selection, request formats, and error normalization remain internal to the backend integration and are not exposed through the RuntimeProfile interface.
+
+### PodTemplate {#podtemplate}
+
+The PodTemplate is a complete `corev1.PodTemplateSpec`, but only one template layer is allowed:
+
+- Each role's `podTemplate` must contain a container named `engine`.
+- `engine` must declare exactly one named port called `http`; in multinode mode, only the Leader is registered as a service Endpoint.
+- All Pods use the Volcano scheduler configured by the Operator. The template's `schedulerName` must be empty or match that configuration.
+- The metadata, containers, resources, and scheduling constraints from the same template apply to the Leader and Workers; the backend adapter generates only role-specific startup configuration and reserved environment variables.
+- `InferenceDeployment` does not provide a second layer of Pod overrides.
+- Template `metadata` may contain only labels and annotations. Resource names, Namespace, OwnerReference, finalizers, and other server-side metadata are managed by the Controller.
+- When `lora` is configured, the template entrypoint must conform to the LoRA contract for the corresponding backend. The Profile declares the engine's LoRA enablement, rank, and backend-specific capacity parameters; the Deployment cannot override them.
+- The Operator injects the management port, volume, mount, and environment variables required by dynamic mode, and the template cannot use these reserved names. A thin stateless proxy is injected only when the backend's native interface cannot satisfy the internal lifecycle contract; the proxy does not own desired state or perform independent reconciliation.
+
+The Operator provides a uniform Model mount contract in every `engine` container:
+
+```text
+volume: fusioninfer-model
+volume: fusioninfer-model-metadata
+initContainer: fusioninfer-model-init
+env: FUSION_MODEL_PATH
+env: FUSION_MODEL_METADATA_PATH
+volume: fusioninfer-lora
+env: FUSION_LORA_ROOT
+env: FUSION_LORA_MANIFEST
+```
+
+Model content is mounted read-only at the fixed path `/models`, and the following values are injected:
+
+```text
+FUSION_MODEL_PATH=/models
+FUSION_MODEL_METADATA_PATH=/var/run/fusioninfer/model/model.json
+```
+
+Runtime commands should read the Model through `$(FUSION_MODEL_PATH)` rather than hard-coding the cache root. A Profile cannot declare the reserved fields above or override the materializer or Endpoint Picker images managed by the Operator.
+
+When LoRA bindings are declared, the Operator also mounts the current Deployment's adapter projection read-only at `/adapters` and generates `/var/run/fusioninfer/lora/adapters.json`. The Manifest uses an internal binding key to map `servedName`, the resolved Model UID, the digest, and the in-container path; paths do not directly use the user-provided served name. The engine container can see only the LoRAs bound to the current Deployment and cannot browse the node cache root.
+
+Inference images in production must be pinned by OCI digest. For readability, the following examples use the official versioned image `vllm/vllm-openai:v0.26.0`; replace it with the corresponding digest-pinned image when deploying.
+
+### Scope and References {#scope-and-references}
+
+`RuntimeProfile` does not contain a `modelRef`. The specific Model, runtime template, and replica counts are bound by `InferenceDeployment`.
+
+A PodTemplate can reference a ServiceAccount, Secret, ConfigMap, and PVC:
+
+- Namespaced dependencies in a `RuntimeProfile` are resolved in the Profile's Namespace.
+- Namespaced dependency names in a `ClusterRuntimeProfile` are resolved in the Namespace of the `InferenceDeployment` that consumes it.
+- A `ClusterRuntimeProfile` cannot pin dependencies in another Namespace.
+- When a `ClusterRuntimeProfile` is created, only the reference structure is validated. The consumer reconciles whether each dependency exists and reports the result through `InferenceDeployment.status`.
+
+The Profile neither owns nor modifies these dependencies. ConfigMaps and Secrets that affect startup behavior should use immutable objects or versioned names.
+
+### Defaults and Validation {#defaults-and-validation}
+
+- `backend` is required and must be `vllm`, `sglang`, or `trtllm`.
+- `lora.loadingMode` must be `preload` or `dynamic`; `maxLoadedAdapters` must be at least 1.
+- A Profile can be consumed only when the current Operator version implements the selected LoRA mode for the specified backend and template entrypoint.
+- `aggregated` must be set, or both `prefiller` and `decoder` must be set.
+- Every declared role must provide a `podTemplate`.
+- When `multinode` is set, `nodeCount` must be at least 2; when it is omitted, the role is treated as single-node.
+- RawExtension must strictly decode as `corev1.PodTemplateSpec`.
+- The template must contain an `engine` container and exactly one named `http` port.
+- The template cannot use Operator-reserved volumes, init containers, environment variables, mount paths, labels, or annotations.
+- The backend adapter must support the image and entrypoint arguments declared in the template.
+- The template cannot declare executor, address, rank, `nnodes`, or headless parameters reserved by the backend adapter.
+- The template image must be pinned by OCI digest.
+- `RuntimeProfile.spec` and `ClusterRuntimeProfile.spec` are immutable in v1. Changing the backend, image, command, resources, `multinode`, or PodTemplate requires a new object.
+
+## Status {#status}
+
+`RuntimeProfile` and `ClusterRuntimeProfile` do not provide a status subresource and do not require a dedicated Controller. Admission validates constraints within the object, while the consuming `InferenceDeployment.status` holds the state of Namespaced dependencies and the actual runtime.
+
+## Examples {#examples}
+
+### RuntimeProfile: Single-Node Aggregated {#runtimeprofile-single-node-aggregated}
+
+This Profile describes an Aggregated logical replica that uses one GPU.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated-a10-r1
+  namespace: team-a
+spec:
+  backend: vllm
+  aggregated:
+    podTemplate:
+      metadata:
+        labels:
+          example.fusioninfer.io/runtime: vllm
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+            ports:
+              - name: http
+                containerPort: 8000
+            readinessProbe:
+              httpGet:
+                path: /health
+                port: http
+            resources:
+              requests:
+                cpu: "4"
+                memory: 16Gi
+              limits:
+                nvidia.com/gpu: "1"
+        nodeSelector:
+          accelerator: a10
+```
+
+### ClusterRuntimeProfile: Prefill/Decode Disaggregation {#clusterruntimeprofile-prefilldecode-disaggregation}
+
+The Prefiller and Decoder declare their KV transfer roles separately. The Profile does not contain replica counts or an Endpoint Picker policy.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: ClusterRuntimeProfile
+metadata:
+  name: vllm-pd-h100-r1
+spec:
+  backend: vllm
+  prefiller:
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --kv-transfer-config
+              - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "2"
+        nodeSelector:
+          accelerator: h100
+  decoder:
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --kv-transfer-config
+              - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "1"
+        nodeSelector:
+          accelerator: h100
+```
+
+### RuntimeProfile: Multinode Aggregated {#runtimeprofile-multinode-aggregated}
+
+Each logical replica consists of one Leader Pod and three Worker Pods, using four nodes in total.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated-4node-r1
+  namespace: team-a
+spec:
+  backend: vllm
+  aggregated:
+    multinode:
+      nodeCount: 4
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --port
+              - "8000"
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "4"
+              - --data-parallel-size
+              - "1"
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+        nodeSelector:
+          accelerator: h100
+```
+
+The `backend: vllm` adapter injects the multiprocessing executor, node count, address, and rank for the Leader and Workers based on `nodeCount: 4`. It preserves the `TP=8`, `PP=4`, and `DP=1` values fixed in the Profile, so the user maintains only one set of vLLM arguments and one PodTemplate.
+
+### RuntimeProfile: Dynamic LoRA {#runtimeprofile-dynamic-lora}
+
+This Profile allows a Deployment to bind up to eight LoRAs dynamically. vLLM's LoRA enablement and backend-specific capacity remain fixed in the PodTemplate. The Operator configures the protected Pod-local management endpoint and the environment variables required for runtime updates, while the `InferenceDeployment` Controller reconciles loading state through the backend integration.
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated-lora-dynamic-r1
+  namespace: team-a
+spec:
+  backend: vllm
+  lora:
+    loadingMode: dynamic
+    maxLoadedAdapters: 8
+  aggregated:
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --enable-lora
+              - --max-loras
+              - "8"
+              - --max-cpu-loras
+              - "8"
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "1"
+        nodeSelector:
+          accelerator: h100
+```

--- a/docs/fusioninfer/docs/design/workload-orchestration.md
+++ b/docs/fusioninfer/docs/design/workload-orchestration.md
@@ -1,0 +1,730 @@
+---
+title: Workload Orchestration
+description: Describe how FusionInfer renders and manages aggregated, Prefill/Decode-disaggregated, and multi-node workloads.
+---
+
+## Design Scope {#design-scope}
+
+FusionInfer generates LeaderWorkerSet (LWS), DisaggregatedSet, and Volcano PodGroup resources from the per-replica runtime configuration defined by [`RuntimeProfile`](./runtime-profile.md) and the replica counts defined by [`InferenceDeployment`](./inference-deployment.md).
+
+## Core Concepts {#core-concepts}
+
+InferenceDeployment uses `replicas.<role>` to control how many replicas run for each role. In multinode scenarios, a replica can consist of multiple Pods that together form a logical replica:
+
+- A single-node logical replica contains one Pod.
+- A multinode logical replica contains one Leader Pod and one or more Worker Pods.
+
+RuntimeProfile defines how each logical replica runs:
+
+- `podTemplate` defines the image, resources, and engine parameters for the Pods in the replica.
+- `multinode.nodeCount` defines how many Pods the replica contains.
+  - When `multinode` is not set, `nodeCount` is treated as 1.
+  - With `nodeCount: 4`, one replica contains one Leader and three Workers.
+
+`nodeCount: 4` in the RuntimeProfile means that each logical replica contains four Pods:
+
+```yaml {10}
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated-4node-r1
+  namespace: team-a
+spec:
+  backend: vllm
+  aggregated:
+    multinode:
+      nodeCount: 4
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "4"
+              - --data-parallel-size
+              - "1"
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+```
+
+`aggregated: 2` in the InferenceDeployment means that two replicas run with the configuration above:
+
+```yaml {16}
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-70b
+  namespace: team-a
+spec:
+  modelRef:
+    kind: ClusterModel
+    name: qwen3-70b-r1
+  runtimeRef:
+    kind: RuntimeProfile
+    name: vllm-aggregated-4node-r1
+  cache:
+    mode: eager
+  replicas:
+    aggregated: 2
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+      sectionName: https
+    hostnames:
+      - qwen3-70b.example.com
+    endpointPicker:
+      strategy: prefix-cache
+```
+
+The resulting resources contain:
+
+```text
+logical replica 0: 1 Leader + 3 Workers
+logical replica 1: 1 Leader + 3 Workers
+
+total Pods: 2 × 4 = 8
+```
+
+## Aggregated Mode {#aggregated-mode}
+
+Aggregated mode generates one LeaderWorkerSet:
+
+- The LWS `spec.replicas` equals `InferenceDeployment.spec.replicas.aggregated`.
+- Each LWS group represents one Aggregated logical replica.
+- `leaderWorkerTemplate.size` equals `nodesPerReplica(aggregated)`.
+- `workerTemplate` is always present. For multinode replicas, `leaderTemplate` is generated as well; both derive from the same RuntimeProfile `podTemplate`.
+- The LWS uses `startupPolicy: LeaderCreated` so that Volcano can observe all Pods in a replica at the same time.
+- Only the Leader Pod is registered with the inference Service and as an InferencePool Endpoint.
+
+Volcano uses the LWS logical replica identity to recognize the Leader and Workers in the same group as one subgroup. Even a single-node logical replica uses an LWS with `size: 1`, allowing single-node and multinode replicas to share the same lifecycle, status aggregation, and routing-selection implementation.
+
+The following configuration uses two logical replicas, each spanning four nodes:
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated-4node-r1
+  namespace: team-a
+spec:
+  backend: vllm
+  aggregated:
+    multinode:
+      nodeCount: 4
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --port
+              - "8000"
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "4"
+              - --data-parallel-size
+              - "1"
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+        nodeSelector:
+          accelerator: h100
+---
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-70b
+  namespace: team-a
+spec:
+  modelRef:
+    kind: ClusterModel
+    name: qwen3-70b-r1
+  runtimeRef:
+    kind: RuntimeProfile
+    name: vllm-aggregated-4node-r1
+  cache:
+    mode: eager
+  replicas:
+    aggregated: 2
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+      sectionName: https
+    hostnames:
+      - qwen3-70b.example.com
+    endpointPicker:
+      strategy: prefix-cache
+```
+
+The RuntimeProfile fixes `nodeCount: 4` and eight GPUs per Pod, while the InferenceDeployment only sets the number of logical replicas to 2. The Controller therefore derives `2 × 4 = 8` Pods and `8 × 8 = 64` GPUs, creates an LWS with `replicas: 2` and `size: 4`, and places both LWS groups in the same revision-scoped PodGroup.
+
+```mermaid
+flowchart TB
+    Deployment["InferenceDeployment<br/>replicas.aggregated = 2"]
+    Runtime["RuntimeProfile<br/>aggregated.nodeCount = 4"]
+    Controller["Workload Renderer"]
+    PodGroup["Volcano PodGroup<br/>minMember = 8<br/>subGroupSize = 4<br/>minSubGroups = 2"]
+
+    LWS["LWS aggregated<br/>replicas = 2, size = 4"]
+    Group0["Logical Replica 0"]
+    Group1["Logical Replica 1"]
+
+    Leader0["Leader 0"]
+    Workers0["3 Workers"]
+    Leader1["Leader 1"]
+    Workers1["3 Workers"]
+
+    Deployment --> Controller
+    Runtime --> Controller
+    Controller --> PodGroup
+    Controller --> LWS
+    PodGroup -.->|"2 subgroups"| LWS
+    LWS --> Group0
+    LWS --> Group1
+    Group0 --> Leader0
+    Group0 --> Workers0
+    Group1 --> Leader1
+    Group1 --> Workers1
+```
+
+### PodGroup {#podgroup}
+
+`minMember: 8` is the global minimum Pod count for the revision. `subGroupPolicy` then groups the four Pods in each LWS logical replica into an atomic scheduling unit:
+
+```yaml
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: PodGroup
+metadata:
+  name: qwen3-70b
+  namespace: team-a
+spec:
+  minMember: 8
+  minResources:
+    nvidia.com/gpu: "64"
+  subGroupPolicy:
+    - name: aggregated
+      labelSelector:
+        matchLabels:
+          fusioninfer.io/role: aggregated
+      matchLabelKeys:
+        - leaderworkerset.sigs.k8s.io/group-index
+      subGroupSize: 4
+      minSubGroups: 2
+```
+
+At runtime, `minResources` aggregates the resource requests from the RuntimeProfile that participate in gang scheduling; the example shows only GPUs. `minSubGroups: 2` corresponds to the Deployment's `replicas.aggregated: 2`, meaning that the PodGroup meets the role's minimum only when both complete four-Pod subgroups are present.
+
+### LeaderWorkerSet {#leaderworkerset}
+
+The two logical replicas are represented by `spec.replicas` in the same LWS. The LWS configuration and the backend-generated differences between Leader and Worker startup are as follows:
+
+```yaml
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: qwen3-70b-aggregated
+  namespace: team-a
+spec:
+  replicas: 2
+  startupPolicy: LeaderCreated
+  rolloutStrategy:
+    type: RollingUpdate
+  leaderWorkerTemplate:
+    size: 4
+    leaderTemplate:
+      spec:
+        schedulerName: volcano
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            command:
+              - vllm
+              - serve
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "4"
+              - --data-parallel-size
+              - "1"
+              - --distributed-executor-backend
+              - mp
+              - --nnodes
+              - "4"
+              - --master-addr
+              - $(LWS_LEADER_ADDRESS)
+              - --master-port
+              - "29500"
+              - --node-rank
+              - "0"
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+    workerTemplate:
+      spec:
+        schedulerName: volcano
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            command:
+              - vllm
+              - serve
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "4"
+              - --data-parallel-size
+              - "1"
+              - --distributed-executor-backend
+              - mp
+              - --nnodes
+              - "4"
+              - --master-addr
+              - $(LWS_LEADER_ADDRESS)
+              - --master-port
+              - "29500"
+              - --node-rank
+              - $(LWS_WORKER_INDEX)
+              - --headless
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+```
+
+The LWS Controller creates two groups from this object. Each group contains one Leader and three Workers, and receives in-group discovery information such as `LWS_LEADER_ADDRESS`:
+
+```text
+logical replica 0: 1 Leader + 3 Workers
+logical replica 1: 1 Leader + 3 Workers
+```
+
+Volcano recognizes these as two four-Pod subgroups. A single-node Aggregated deployment uses the same PodGroup structure, except that each subgroup has a `subGroupSize` of 1.
+
+## Disaggregated P/D Mode {#disaggregated-pd-mode}
+
+A Prefill/Decode Profile contains both `prefiller` and `decoder`. The Controller generates one DisaggregatedSet for the entire P/D revision; each role maps to a LeaderWorkerSet managed by the DisaggregatedSet. The two roles can have different Pod templates, logical replica counts, and `nodeCount` values. The DisaggregatedSet owns the unified revision, coordinated rollout, role status, and Headless Service.
+
+This mapping requires LeaderWorkerSet v0.9.0 or later, including the `disaggregatedset.x-k8s.io/v1` CRD, to be installed in the cluster. The Controller discovers this API at startup. If it is missing, the P/D InferenceDeployment sets `WorkloadsReady=False` with reason `DisaggregatedSetUnavailable`.
+
+The following configuration assigns two nodes to each Prefiller replica and four nodes to each Decoder replica. The InferenceDeployment requests one Prefiller replica and two Decoder replicas:
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: ClusterRuntimeProfile
+metadata:
+  name: vllm-pd-2x4-h100-r1
+spec:
+  backend: vllm
+  prefiller:
+    multinode:
+      nodeCount: 2
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --port
+              - "8000"
+              - --tensor-parallel-size
+              - "16"
+              - --data-parallel-size
+              - "1"
+              - --kv-transfer-config
+              - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+        nodeSelector:
+          accelerator: h100
+  decoder:
+    multinode:
+      nodeCount: 4
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --port
+              - "8000"
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "4"
+              - --data-parallel-size
+              - "1"
+              - --kv-transfer-config
+              - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+        nodeSelector:
+          accelerator: h100
+---
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-pd
+  namespace: team-a
+spec:
+  modelRef:
+    kind: ClusterModel
+    name: qwen3-70b-r1
+  runtimeRef:
+    kind: ClusterRuntimeProfile
+    name: vllm-pd-2x4-h100-r1
+  cache:
+    mode: eager
+  replicas:
+    prefiller: 1
+    decoder: 2
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+      sectionName: https
+    hostnames:
+      - qwen3-pd.example.com
+```
+
+`endpoint.endpointPicker` is omitted because P/D routing is inferred from the `prefiller + decoder` role combination. The Pod count for each role is calculated from its own `nodeCount` and `replicas`:
+
+```text
+prefiller pods = 1 × 2 = 2
+decoder pods   = 2 × 4 = 8
+total pods     = 10
+```
+
+```mermaid
+flowchart TB
+    Deployment["InferenceDeployment<br/>prefiller = 1, decoder = 2"]
+    Runtime["RuntimeProfile<br/>prefiller.nodeCount = 2<br/>decoder.nodeCount = 4"]
+    Controller["Workload Renderer"]
+    DS["DisaggregatedSet"]
+    PodGroup["Shared Volcano PodGroup<br/>minMember = 10<br/>prefiller: 2 × 1 subgroup<br/>decoder: 4 × 2 subgroups"]
+
+    Prefill["Prefiller LWS<br/>replicas = 1, size = 2"]
+    Decode["Decoder LWS<br/>replicas = 2, size = 4"]
+
+    Deployment --> Controller
+    Runtime --> Controller
+    Controller --> PodGroup
+    Controller --> DS
+    DS --> Prefill
+    DS --> Decode
+    PodGroup -.->|"1 prefiller subgroup"| Prefill
+    PodGroup -.->|"2 decoder subgroups"| Decode
+```
+
+### PodGroup {#podgroup-1}
+
+Both P/D roles join the same PodGroup, but each has an independent subgroup rule:
+
+```yaml
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: PodGroup
+metadata:
+  name: qwen3-pd
+  namespace: team-a
+spec:
+  minMember: 10
+  subGroupPolicy:
+    - name: prefiller
+      labelSelector:
+        matchLabels:
+          fusioninfer.io/role: prefiller
+      matchLabelKeys:
+        - leaderworkerset.sigs.k8s.io/group-index
+      subGroupSize: 2
+      minSubGroups: 1
+    - name: decoder
+      labelSelector:
+        matchLabels:
+          fusioninfer.io/role: decoder
+      matchLabelKeys:
+        - leaderworkerset.sigs.k8s.io/group-index
+      subGroupSize: 4
+      minSubGroups: 2
+```
+
+This configuration requires at least one complete Prefiller subgroup and two complete Decoder subgroups. `minMember: 10` also requires all ten Pods across the three subgroups to enter the PodGroup's minimum scheduling set.
+
+### DisaggregatedSet {#disaggregatedset}
+
+The InferenceDeployment Controller compiles the two RuntimeProfile roles into the same DisaggregatedSet. The role, replica, and node-count mapping is as follows:
+
+```yaml
+apiVersion: disaggregatedset.x-k8s.io/v1
+kind: DisaggregatedSet
+metadata:
+  name: qwen3-pd
+  namespace: team-a
+spec:
+  roles:
+    - name: prefiller
+      spec:
+        replicas: 1
+        startupPolicy: LeaderCreated
+        leaderWorkerTemplate:
+          size: 2
+          leaderTemplate:
+            spec:
+              schedulerName: volcano
+              containers:
+                - name: engine
+                  image: vllm/vllm-openai:v0.26.0
+          workerTemplate:
+            spec:
+              schedulerName: volcano
+              containers:
+                - name: engine
+                  image: vllm/vllm-openai:v0.26.0
+
+    - name: decoder
+      spec:
+        replicas: 2
+        startupPolicy: LeaderCreated
+        leaderWorkerTemplate:
+          size: 4
+          leaderTemplate:
+            spec:
+              schedulerName: volcano
+              containers:
+                - name: engine
+                  image: vllm/vllm-openai:v0.26.0
+          workerTemplate:
+            spec:
+              schedulerName: volcano
+              containers:
+                - name: engine
+                  image: vllm/vllm-openai:v0.26.0
+```
+
+The DisaggregatedSet Controller generates one child LWS for each role and manages the coordinated rollout and Headless Service for both roles.
+
+### Role LeaderWorkerSets {#role-leaderworkersets}
+
+The DisaggregatedSet creates one LWS for each role. The key mapping is as follows:
+
+```yaml
+# Prefiller
+kind: LeaderWorkerSet
+spec:
+  replicas: 1
+  startupPolicy: LeaderCreated
+  leaderWorkerTemplate:
+    size: 2
+---
+# Decoder
+kind: LeaderWorkerSet
+spec:
+  replicas: 2
+  startupPolicy: LeaderCreated
+  leaderWorkerTemplate:
+    size: 4
+```
+
+The Prefiller LWS creates one two-Pod logical replica, while the Decoder LWS creates two four-Pod logical replicas. The Leader and Worker startup configurations in the role templates derive from the same RuntimeProfile `podTemplate` and backend adapter.
+
+Even when every logical replica is single-node, a P/D deployment uses a shared PodGroup to coordinate the minimum available set of Prefillers and Decoders. The DisaggregatedSet manages the role workloads, while FusionInfer manages model materialization, the shared PodGroup, and GAIE routing. The Endpoint Picker and InferencePool switch traffic only after all desired roles in the pending revision are ready.
+
+## Backend Distributed Execution {#backend-distributed-execution}
+
+RuntimeProfile supplies one `podTemplate` for each inference role. The Controller generates Leader and Worker configurations from the template, and the backend adapter then modifies the startup arguments of the `engine` container. `backend` selects only the adapter; it does not select the image, model, or parallelism.
+
+### Leader and Worker Startup {#leader-and-worker-startup}
+
+When `multinode` is not set, the adapter does not add cross-node startup arguments. When `multinode` is set, the same template produces two role-specific configurations:
+
+- The Leader uses rank 0, establishes the distributed execution environment, and starts the inference process that serves HTTP externally.
+- Each Worker joins the Leader at the rank assigned by LWS and is not registered with the Service or as an InferencePool Endpoint.
+- The image, TP/PP/DP, resources, environment variables, volumes, and scheduling constraints come from the original `podTemplate`.
+- When a Worker does not run an HTTP service, the adapter removes the HTTP readiness, liveness, and startup probes inherited from the original template.
+
+LeaderWorkerSet provides the following in-group information:
+
+```text
+LWS_LEADER_ADDRESS   In-group address of the Leader Pod
+LWS_WORKER_INDEX     Index of the Worker in the current group
+LWS_GROUP_SIZE       Total number of Pods in the current group
+```
+
+The backend adapter translates these values into engine-specific executor, address, rank, and node-count arguments. RuntimeProfile cannot declare adapter-managed executor, address, rank, `nnodes`, or headless arguments; if a conflict occurs, the Controller rejects workload generation.
+
+### vLLM {#vllm}
+
+Multinode vLLM always uses the native multiprocessing executor. RuntimeProfile declares only the model and engine parameters such as TP/PP/DP; the backend adapter injects `--distributed-executor-backend mp` and the in-group startup arguments into each Pod.
+
+Every Pod runs `vllm serve`. The Leader uses:
+
+```text
+--distributed-executor-backend mp
+--nnodes 4
+--master-addr $(LWS_LEADER_ADDRESS)
+--master-port 29500
+--node-rank 0
+```
+
+Each Worker uses the same model and parallelism arguments and joins the distributed process group in headless mode:
+
+```text
+--distributed-executor-backend mp
+--nnodes 4
+--master-addr $(LWS_LEADER_ADDRESS)
+--master-port 29500
+--node-rank $(LWS_WORKER_INDEX)
+--headless
+```
+
+The Leader serves HTTP externally, while Workers participate only in distributed execution. Before starting a Worker, the adapter waits for the Leader's multiprocessing rendezvous port to become available. TP/PP/DP retain their original RuntimeProfile values and are not adjusted automatically based on `nodeCount`.
+
+### SGLang {#sglang}
+
+SGLang uses its native distributed launch. The Profile author declares the model parameters, `--tp-size`, `--dp-size`, and per-Pod GPU resources, while the adapter adds `dist-init-addr`, `nnodes`, and `node-rank` to each Pod.
+
+The Leader uses:
+
+```bash
+python3 -m sglang.launch_server \
+  --model-path "${FUSION_MODEL_PATH}" \
+  --tp-size 16 \
+  --dp-size 1 \
+  --dist-init-addr "${LWS_LEADER_ADDRESS}:29500" \
+  --nnodes 2 \
+  --node-rank 0
+```
+
+Each Worker uses the same engine parameters, with only the rank substituted:
+
+```bash
+python3 -m sglang.launch_server \
+  --model-path "${FUSION_MODEL_PATH}" \
+  --tp-size 16 \
+  --dp-size 1 \
+  --dist-init-addr "${LWS_LEADER_ADDRESS}:29500" \
+  --nnodes 2 \
+  --node-rank "${LWS_WORKER_INDEX}"
+```
+
+Only rank 0 serves HTTP. The other ranks run the SGLang scheduler and distributed compute processes but are not registered as routable Endpoints.
+
+### Parameter Ownership and Validation {#parameter-ownership-and-validation}
+
+RuntimeProfile owns the model parameters, TP/PP/DP, image, and per-Pod resources. The backend adapter selects the multiprocessing executor for vLLM and adds the address, rank, node count, and headless arguments that vary between Leaders and Workers; LWS provides the in-group address and index.
+
+The adapter accepts only entry-point forms explicitly supported by the Operator version, such as `vllm serve` and `python3 -m sglang.launch_server`. It can recognize a limited, version-constrained set of arguments, but it does not parse arbitrary shell scripts or validate the mathematical compatibility of the model architecture with TP/PP/DP. An unrecognized entry point, duplicate reserved arguments, or an unsupported argument combination leaves the new workload uncreated.
+
+## Gang Scheduling {#gang-scheduling}
+
+Both Aggregated and disaggregated P/D modes use Volcano gang scheduling, whether a replica contains one Pod or multiple Pods.
+
+Before creating a standalone LWS or DisaggregatedSet, the Controller creates a revision-scoped PodGroup. The PodGroup aggregates all logical replicas:
+
+```text
+minMember =
+    Σ replicas(role) × nodesPerReplica(role)
+
+subGroupPolicy[role].subGroupSize =
+    nodesPerReplica(role)
+
+subGroupPolicy[role].minSubGroups =
+    replicas(role)
+```
+
+The two levels have distinct responsibilities:
+
+- `minMember` is the global minimum Pod count for the entire revision and participates in PodGroup admission together with `minResources`.
+- `subGroupPolicy` forms subgroups by role and LWS logical replica.
+- `subGroupSize` ensures that the Leader and Workers of a logical replica are scheduled as an atomic unit.
+- `minSubGroups` ensures that the scheduling requirements are met for at least the specified number of complete logical replicas for the role.
+
+When replicas are added, the Controller updates `spec.replicas` on the standalone LWS or on the DisaggregatedSet role, and updates the PodGroup's `minMember` and the corresponding role's `minSubGroups`. Each role requires only one `subGroupPolicy`.
+
+### PodGroup Admission Semantics {#podgroup-admission-semantics}
+
+PodGroup uses two levels: global admission and logical-replica atomicity:
+
+- `minMember` defines the minimum Pod count for the entire revision.
+- `subGroupSize` defines the number of Pods in each logical replica.
+- `minSubGroups` defines the number of complete logical replicas required for the corresponding role.
+
+Two four-node Aggregated replicas correspond to `minMember: 8`, `subGroupSize: 4`, and `minSubGroups: 2`. Each four-Pod logical replica is scheduled as one subgroup, and the two subgroups together form the minimum available set for the revision.
+
+The shared PodGroup's `minMember` covers every desired member of the pending revision, so the revision does not support scheduling only part of the desired capacity. When resources are insufficient, the new LWS remains Pending and the previous active revision continues to receive traffic. This behavior matches the promotion condition that a revision is promoted only after all desired logical replicas are Ready.
+
+The Controller sets each generated Pod's `schedulerName` to the Volcano scheduler configured for the Operator. `schedulerName` in the RuntimeProfile must be unset or match that value; a conflicting value is rejected rather than silently overwritten.
+
+`SubGroupPolicy` requires Volcano v1.14 or later. At startup, the Operator must discover whether the PodGroup CRD includes `spec.subGroupPolicy`. If that capability is missing, the InferenceDeployment sets `WorkloadsReady=False` with reason `UnsupportedVolcanoVersion`; it cannot silently degrade to scheduling with only `minMember`.
+
+## Scaling {#scaling}
+
+Changing only `replicas` in the InferenceDeployment does not change the node count, Pod resources, or engine parameters in the RuntimeProfile:
+
+- Scaling Aggregated replicas updates `spec.replicas` on the standalone LWS.
+- Scaling P/D replicas updates `spec.replicas` on the corresponding DisaggregatedSet role, after which the DisaggregatedSet drives the child LWS.
+- Scaling out updates the PodGroup's `minMember`, the corresponding role's `subGroupPolicy.minSubGroups`, and `minResources` at the same time; `subGroupSize` remains unchanged.
+- Scaling in first stops advertising the Leaders of logical replicas marked for deletion as routable Endpoints, then decreases the role replicas and contracts the PodGroup.
+- `nodeCount`, Pod resources, and TP/PP/DP cannot be scaled through the Deployment; these changes require a new RuntimeProfile and a complete revision rollout.
+
+For a deployment using dynamic LoRA, a new logical replica joins the routable Endpoint set only after all declared LoRAs have finished loading. When a replica is removed, new Base Model and LoRA requests are stopped first, then bindings are unloaded and the LWS group is scaled down. Preload mode adds no separate step because the LoRAs already belong to the workload revision.
+
+When the resources required for gang scale-out are unavailable, existing logical replicas continue serving and the Deployment reports `Progressing=True` and `WorkloadsReady=False`. The Controller does not delete existing replicas first to free resources for new replicas.
+
+## Rollout and Failure Handling {#rollout-and-failure-handling}
+
+Changes to the Model, RuntimeProfile, or cache mode produce a new template hash. The Controller creates a separate warm-up job, PodGroup, standalone LWS or DisaggregatedSet, role Services, and Endpoint Picker for the pending revision instead of modifying the active revision's Pod templates in place.
+
+With `loadingMode: preload`, the resolved LoRA references, digests, and `servedName` values participate in the template hash, and binding changes use the same complete rollout. With `loadingMode: dynamic`, the LoRA set uses a separate binding revision; a loading or unloading failure does not replace the Base Model workload or affect other LoRAs that are already Ready.
+
+The new revision is promoted only when all of the following conditions are met:
+
+- The required model copies have been materialized.
+- In preload mode, all LoRAs have been materialized and started successfully with the engine.
+- The Leader and all Workers in every logical replica are Ready.
+- All desired Aggregated or Prefill/Decode logical replicas are Ready.
+- The role Services have produced Ready Endpoints.
+- The Endpoint Picker and InferencePool are ready.
+
+If the PodGroup cannot be scheduled, the LWS or DisaggregatedSet fails to start, the coordinated role rollout fails, or the backend adapter rejects the template, the Controller retains the active revision and reports the failure reason through InferenceDeployment Conditions. Deleting an InferenceDeployment also reclaims its workload and routing resources; node model caches are reclaimed independently according to the global retention policy.
+
+## Status Mapping {#status-mapping}
+
+`InferenceDeployment.status.components.<role>` aggregates the underlying status by logical replica:
+
+- `desiredReplicas` comes from `spec.replicas.<role>`.
+- `nodesPerReplica` comes from the RuntimeProfile's `multinode.nodeCount`, or 1 when it is not set.
+- Aggregated `readyReplicas` comes from the group Ready status of the standalone LWS.
+- The `readyReplicas` values for Prefiller and Decoder come from the DisaggregatedSet role status and the corresponding child LWS; a group counts only when all of its member Pods are Ready.
+- `readyPods` records the current total number of Ready Pods.
+
+Users observe workload reconciliation results through the `WorkloadsReady`, `Progressing`, and `Degraded` Conditions.

--- a/docs/fusioninfer/docs/design/workload-orchestration.md
+++ b/docs/fusioninfer/docs/design/workload-orchestration.md
@@ -38,7 +38,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --tensor-parallel-size
@@ -124,7 +124,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --port
@@ -251,7 +251,7 @@ spec:
         schedulerName: volcano
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             command:
               - vllm
               - serve
@@ -284,7 +284,7 @@ spec:
         schedulerName: volcano
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             command:
               - vllm
               - serve
@@ -343,7 +343,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --port
@@ -369,7 +369,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --port
@@ -502,13 +502,13 @@ spec:
               schedulerName: volcano
               containers:
                 - name: engine
-                  image: vllm/vllm-openai:v0.26.0
+                  image: vllm/vllm-openai:v0.27.1
           workerTemplate:
             spec:
               schedulerName: volcano
               containers:
                 - name: engine
-                  image: vllm/vllm-openai:v0.26.0
+                  image: vllm/vllm-openai:v0.27.1
 
     - name: decoder
       spec:
@@ -521,13 +521,13 @@ spec:
               schedulerName: volcano
               containers:
                 - name: engine
-                  image: vllm/vllm-openai:v0.26.0
+                  image: vllm/vllm-openai:v0.27.1
           workerTemplate:
             spec:
               schedulerName: volcano
               containers:
                 - name: engine
-                  image: vllm/vllm-openai:v0.26.0
+                  image: vllm/vllm-openai:v0.27.1
 ```
 
 The DisaggregatedSet Controller generates one child LWS for each role and manages the coordinated rollout and Headless Service for both roles.

--- a/docs/fusioninfer/docs/intro.md
+++ b/docs/fusioninfer/docs/intro.md
@@ -140,7 +140,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args: ["--model", "Qwen/Qwen3-8B"]
               resources:
                 limits:

--- a/docs/fusioninfer/docs/user-guide/deployment.md
+++ b/docs/fusioninfer/docs/user-guide/deployment.md
@@ -33,7 +33,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args: ["--model", "Qwen/Qwen3-8B"]
               resources:
                 limits:
@@ -66,7 +66,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args: ["--model", "Qwen/Qwen3-8B", "--tensor-parallel-size", "2"]
               resources:
                 limits:

--- a/docs/fusioninfer/docusaurus.config.ts
+++ b/docs/fusioninfer/docusaurus.config.ts
@@ -2,6 +2,8 @@ import { themes as prismThemes } from 'prism-react-renderer';
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
+const docsEditUrl = 'https://github.com/fusioninfer/fusioninfer/edit/main/docs/fusioninfer/';
+
 const config: Config = {
   title: 'FusionInfer',
   tagline: 'A Kubernetes-native platform for distributed LLM inference orchestration',
@@ -24,8 +26,20 @@ const config: Config = {
   trailingSlash: false,
 
   i18n: {
+    path: 'i18n',
     defaultLocale: 'en',
-    locales: ['en'],
+    locales: ['en', 'zh'],
+    localeConfigs: {
+      en: {
+        label: 'English',
+        htmlLang: 'en',
+      },
+      zh: {
+        path: 'zh-Hans',
+        label: '简体中文',
+        htmlLang: 'zh-CN',
+      },
+    },
   },
 
   markdown: {
@@ -42,14 +56,16 @@ const config: Config = {
       {
         docs: {
           sidebarPath: './sidebars.ts',
-          editUrl: 'https://github.com/fusioninfer/fusioninfer/tree/main/docs/fusioninfer/',
+          editUrl: docsEditUrl,
+          editLocalizedFiles: true,
         },
         blog: {
           routeBasePath: 'blog',
           showReadingTime: true,
           blogSidebarTitle: 'All posts',
           blogSidebarCount: 'ALL',
-          editUrl: 'https://github.com/fusioninfer/fusioninfer/tree/main/docs/fusioninfer/',
+          editUrl: docsEditUrl,
+          editLocalizedFiles: true,
         },
         theme: {
           customCss: './src/css/custom.css',
@@ -64,10 +80,18 @@ const config: Config = {
       '@easyops-cn/docusaurus-search-local',
       {
         hashed: 'filename',
-        language: ['en'],
+        language: ['en', 'zh'],
         indexDocs: true,
         indexBlog: true,
         indexPages: false,
+        docsDir: [
+          'docs',
+          'i18n/zh-Hans/docusaurus-plugin-content-docs/current',
+        ],
+        blogDir: [
+          'blog',
+          'i18n/zh-Hans/docusaurus-plugin-content-blog',
+        ],
         docsRouteBasePath: '/docs',
         blogRouteBasePath: '/blog',
         highlightSearchTermsOnTargetPage: true,
@@ -107,6 +131,10 @@ const config: Config = {
           label: 'Blogs',
           position: 'right',
         },
+        {
+          type: 'localeDropdown',
+          position: 'right',
+        },
       ],
     },
     footer: {
@@ -124,8 +152,8 @@ const config: Config = {
               to: '/docs/user-guide/deployment',
             },
             {
-              label: 'Architecture',
-              to: '/docs/design/core-design',
+              label: 'Design',
+              to: '/docs/design/model-serving',
             },
           ],
         },

--- a/docs/fusioninfer/i18n/zh-Hans/code.json
+++ b/docs/fusioninfer/i18n/zh-Hans/code.json
@@ -1,0 +1,732 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "页面已崩溃。",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "回到顶部",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "历史博文",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "历史博文",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "博文列表分页导航",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "较新的博文",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "较旧的博文",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "博文分页导航",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "较新一篇",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "较旧一篇",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "系统模式",
+    "description": "The name for the system color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "浅色模式",
+    "description": "The name for the light color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "暗黑模式",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "切换浅色/暗黑模式（当前为{mode}）",
+    "description": "The ARIA label for the color mode toggle"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "查看所有标签",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "{count} 个项目",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "页面路径",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "文档分页导航",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "上一页",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "下一页",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "{count} 篇文档带有标签",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged}「{tagName}」",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "版本：{versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "此为 {siteTitle} {versionLabel} 版尚未发行的文档。",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "此为 {siteTitle} {versionLabel} 版的文档，现已不再积极维护。",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "最新的文档请参阅 {latestVersionLink} ({versionLabel})。",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "最新版本",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "编辑此页",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "{heading}的直接链接",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": "于 {date} ",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": "由 {user} ",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "最后{byUser}{atDate}更新",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.NotFound.title": {
+    "message": "找不到页面",
+    "description": "The title of the 404 page"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "选择版本",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "标签：",
+    "description": "The label alongside a tag list"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "关闭",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.admonition.caution": {
+    "message": "警告",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "危险",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "信息",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "备注",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "提示",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "注意",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "最近博文导航",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "展开侧边栏分类 '{label}'",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "折叠侧边栏分类 '{label}'",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "（在新标签页中打开）",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "主导航",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.NotFound.p1": {
+    "message": "我们找不到您要找的页面。",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "请联系原始链接来源网站的所有者，并告知他们链接已损坏。",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "选择语言",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "本页总览",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "阅读需 {readingTime} 分钟",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.post.readMore": {
+    "message": "阅读更多",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "阅读 {title} 的全文",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "复制",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "复制成功",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "复制代码到剪贴板",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "切换自动换行",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "主页面",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "文档侧边栏",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "收起侧边栏",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "收起侧边栏",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "关闭导航栏",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← 回到主菜单",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "切换导航栏",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "展开下拉菜单",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "折叠下拉菜单",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "展开侧边栏",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "展开侧边栏",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.SearchBar.noResultsText": {
+    "message": "没有找到任何文档"
+  },
+  "theme.SearchBar.seeAllOutsideContext": {
+    "message": "查看“{context}”以外的全部结果"
+  },
+  "theme.SearchBar.searchInContext": {
+    "message": "查看“{context}”以内的全部结果"
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "查看全部结果"
+  },
+  "theme.SearchBar.label": {
+    "message": "搜索",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "“{query}”的搜索结果",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "搜索文档",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.searchContext.everywhere": {
+    "message": "所有"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "共找到 {count} 篇文档",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "没有找到任何文档",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.blog.post.plurals": {
+    "message": "{count} 篇博文",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} 含有标签「{tagName}」",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "作者",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "查看所有作者",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "该作者尚未撰写任何文章。",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "未列出页",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "此页面未列出。搜索引擎不会对其索引，只有拥有直接链接的用户才能访问。",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "草稿页",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "此页面是草稿，仅在开发环境中可见，不会包含在正式版本中。",
+    "description": "The draft content banner message"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "重试",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "跳到主要内容",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "标签",
+    "description": "The title of the tag list page"
+  },
+  "homepage.features.oneApi.title": {
+    "message": "一个声明式 API",
+    "description": "Title of the declarative API homepage feature"
+  },
+  "homepage.features.oneApi.description": {
+    "message": "通过单个 InferenceService 自定义资源描述完整的服务拓扑。",
+    "description": "Description of the declarative API homepage feature"
+  },
+  "homepage.features.topologies.title": {
+    "message": "一体式或分离式",
+    "description": "Title of the serving topologies homepage feature"
+  },
+  "homepage.features.topologies.description": {
+    "message": "运行标准 Worker 拓扑，或拆分 Prefill 和 Decode 角色，而无需更改控制平面。",
+    "description": "Description of the serving topologies homepage feature"
+  },
+  "homepage.features.multiNode.title": {
+    "message": "多节点推理",
+    "description": "Title of the multi-node inference homepage feature"
+  },
+  "homepage.features.multiNode.description": {
+    "message": "使用 LeaderWorkerSet 和明确的每副本节点数来协调分布式推理副本。",
+    "description": "Description of the multi-node inference homepage feature"
+  },
+  "homepage.features.routing.title": {
+    "message": "推理感知路由",
+    "description": "Title of the inference-aware routing homepage feature"
+  },
+  "homepage.features.routing.description": {
+    "message": "可选择前缀缓存、KV 缓存利用率、队列大小、LoRA 亲和性或 P/D 路由策略。",
+    "description": "Description of the inference-aware routing homepage feature"
+  },
+  "homepage.features.gangScheduling.title": {
+    "message": "Gang 调度",
+    "description": "Title of the gang scheduling homepage feature"
+  },
+  "homepage.features.gangScheduling.description": {
+    "message": "创建 Volcano PodGroup，使一个分布式副本所需的所有 Pod 能够作为一组进行调度。",
+    "description": "Description of the gang scheduling homepage feature"
+  },
+  "homepage.features.gatewayApi.title": {
+    "message": "原生支持 Gateway API",
+    "description": "Title of the Gateway API homepage feature"
+  },
+  "homepage.features.gatewayApi.description": {
+    "message": "生成 HTTPRoute 和 InferencePool 资源，以及 Endpoint Picker 部署及其配套配置。",
+    "description": "Description of the Gateway API homepage feature"
+  },
+  "homepage.workflows.worker.label": {
+    "message": "部署 Worker",
+    "description": "Tab label for the single-worker deployment workflow"
+  },
+  "homepage.workflows.worker.title": {
+    "message": "从单一服务角色开始",
+    "description": "Title of the single-worker deployment workflow"
+  },
+  "homepage.workflows.worker.description": {
+    "message": "声明模型容器和副本。FusionInfer 会调和其所需的 Kubernetes 资源。",
+    "description": "Description of the single-worker deployment workflow"
+  },
+  "homepage.workflows.disaggregated.label": {
+    "message": "拆分 Prefill/Decode",
+    "description": "Tab label for the disaggregated serving workflow"
+  },
+  "homepage.workflows.disaggregated.title": {
+    "message": "独立扩缩每个推理阶段",
+    "description": "Title of the disaggregated serving workflow"
+  },
+  "homepage.workflows.disaggregated.description": {
+    "message": "将 Prefiller 和 Decoder 设为一等角色，构建 P/D 分离式服务拓扑。",
+    "description": "Description of the disaggregated serving workflow"
+  },
+  "homepage.workflows.routing.label": {
+    "message": "智能路由",
+    "description": "Tab label for the inference-aware routing workflow"
+  },
+  "homepage.workflows.routing.title": {
+    "message": "在服务入口前置推理感知路由",
+    "description": "Title of the inference-aware routing workflow"
+  },
+  "homepage.workflows.routing.description": {
+    "message": "添加 Router 角色并选择内置策略，同时保留高级 EPP 配置能力。",
+    "description": "Description of the inference-aware routing workflow"
+  },
+  "homepage.useCases.monolithic.eyebrow": {
+    "message": "01 / 简单",
+    "description": "Category label for the monolithic serving use case"
+  },
+  "homepage.useCases.monolithic.title": {
+    "message": "一体式服务",
+    "description": "Title of the monolithic serving use case"
+  },
+  "homepage.useCases.monolithic.description": {
+    "message": "当简单性和快速迭代最重要时，将完整的请求生命周期保留在单个 Worker 角色中。",
+    "description": "Description of the monolithic serving use case"
+  },
+  "homepage.useCases.monolithic.details.workerReplicas": {
+    "message": "Worker 副本",
+    "description": "Worker replica detail for the monolithic serving use case"
+  },
+  "homepage.useCases.monolithic.details.singleNode": {
+    "message": "适用于单节点",
+    "description": "Single-node detail for the monolithic serving use case"
+  },
+  "homepage.useCases.monolithic.details.openAi": {
+    "message": "兼容 OpenAI 的引擎",
+    "description": "Engine compatibility detail for the monolithic serving use case"
+  },
+  "homepage.useCases.disaggregated.eyebrow": {
+    "message": "02 / 专用",
+    "description": "Category label for the prefill/decode use case"
+  },
+  "homepage.useCases.disaggregated.title": {
+    "message": "预填充/解码",
+    "description": "Title of the prefill/decode use case"
+  },
+  "homepage.useCases.disaggregated.description": {
+    "message": "将提示词处理与词元生成分离，使每个阶段都可独立配置资源和扩缩容。",
+    "description": "Description of the prefill/decode use case"
+  },
+  "homepage.useCases.disaggregated.details.roles": {
+    "message": "专用角色",
+    "description": "Role detail for the prefill/decode use case"
+  },
+  "homepage.useCases.disaggregated.details.replicas": {
+    "message": "独立副本数",
+    "description": "Replica count detail for the prefill/decode use case"
+  },
+  "homepage.useCases.disaggregated.details.routing": {
+    "message": "P/D 感知路由",
+    "description": "Routing detail for the prefill/decode use case"
+  },
+  "homepage.useCases.multiNode.eyebrow": {
+    "message": "03 / 分布式",
+    "description": "Category label for the multi-node inference use case"
+  },
+  "homepage.useCases.multiNode.title": {
+    "message": "多节点推理",
+    "description": "Title of the multi-node inference use case"
+  },
+  "homepage.useCases.multiNode.description": {
+    "message": "通过明确的副本拓扑和协同调度，跨多个节点运行模型。",
+    "description": "Description of the multi-node inference use case"
+  },
+  "homepage.useCases.multiNode.details.tensorParallel": {
+    "message": "张量并行工作负载",
+    "description": "Tensor parallel detail for the multi-node inference use case"
+  },
+  "homepage.demos.prefixCache.label": {
+    "message": "前缀缓存路由",
+    "description": "Tab label for the prefix-cache routing demo"
+  },
+  "homepage.demos.prefixCache.title": {
+    "message": "将共享前缀路由到合适的副本",
+    "description": "Title of the prefix-cache routing demo"
+  },
+  "homepage.demos.prefixCache.description": {
+    "message": "了解推理感知路由如何在重复请求之间复用前缀缓存状态。",
+    "description": "Description of the prefix-cache routing demo"
+  },
+  "homepage.demos.prefixCache.steps.send": {
+    "message": "发送共享同一提示词前缀的请求。",
+    "description": "First transcript step of the prefix-cache routing demo"
+  },
+  "homepage.demos.prefixCache.steps.observe": {
+    "message": "观察前缀缓存感知路由选择服务副本。",
+    "description": "Second transcript step of the prefix-cache routing demo"
+  },
+  "homepage.demos.prefixCache.steps.confirm": {
+    "message": "确认请求到达所选 Worker。",
+    "description": "Third transcript step of the prefix-cache routing demo"
+  },
+  "homepage.demos.multiNode.label": {
+    "message": "多节点推理",
+    "description": "Tab label for the multi-node inference demo"
+  },
+  "homepage.demos.multiNode.title": {
+    "message": "协调分布式模型副本",
+    "description": "Title of the multi-node inference demo"
+  },
+  "homepage.demos.multiNode.description": {
+    "message": "了解 FusionInfer 如何通过一个 InferenceService 管理多节点生命周期。",
+    "description": "Description of the multi-node inference demo"
+  },
+  "homepage.demos.multiNode.steps.apply": {
+    "message": "应用一个具有多节点副本拓扑的 InferenceService。",
+    "description": "First transcript step of the multi-node inference demo"
+  },
+  "homepage.demos.multiNode.steps.observe": {
+    "message": "观察分布式工作负载和协同调度资源。",
+    "description": "Second transcript step of the multi-node inference demo"
+  },
+  "homepage.demos.multiNode.steps.send": {
+    "message": "在副本就绪后发送推理请求。",
+    "description": "Third transcript step of the multi-node inference demo"
+  },
+  "homepage.githubStars.readyLabel": {
+    "message": "{count} 个星标",
+    "description": "Accessible GitHub star count on the homepage"
+  },
+  "homepage.githubStars.loadingLabel": {
+    "message": "正在加载星标数",
+    "description": "Accessible loading state for the GitHub star count"
+  },
+  "homepage.githubStars.errorLabel": {
+    "message": "无法获取星标数",
+    "description": "Accessible error state for the GitHub star count"
+  },
+  "homepage.githubStars.buttonAriaLabel": {
+    "message": "在 GitHub 上为 FusionInfer 加星，{countLabel}",
+    "description": "Accessible label for the homepage GitHub star button"
+  },
+  "homepage.githubStars.buttonLabel": {
+    "message": "加星",
+    "description": "Visible label for the homepage GitHub star button"
+  },
+  "homepage.hero.visualAriaLabel": {
+    "message": "FusionInfer 架构概览",
+    "description": "Accessible label for the homepage hero architecture visual"
+  },
+  "homepage.hero.nodes.oneApi": {
+    "message": "单一 API",
+    "description": "Label for the API node in the homepage hero visual"
+  },
+  "homepage.hero.nodes.smartRouting": {
+    "message": "智能路由",
+    "description": "Label for the routing node in the homepage hero visual"
+  },
+  "homepage.hero.nodes.multiNode": {
+    "message": "多节点",
+    "description": "Label for the multi-node node in the homepage hero visual"
+  },
+  "homepage.hero.nodes.scheduling": {
+    "message": "调度",
+    "description": "Label for the scheduling node in the homepage hero visual"
+  },
+  "homepage.hero.title": {
+    "message": "面向 LLM 推理的 Kubernetes 原生平台。",
+    "description": "Primary heading on the FusionInfer homepage"
+  },
+  "homepage.hero.description": {
+    "message": "通过一个声明式 API 编排一体式、Prefill/Decode 和多节点服务，并内置智能路由与调度。",
+    "description": "Primary description on the FusionInfer homepage"
+  },
+  "homepage.hero.ecosystemAriaLabel": {
+    "message": "FusionInfer 生态集成",
+    "description": "Accessible label for the homepage ecosystem integrations"
+  },
+  "homepage.hero.ecosystemLabel": {
+    "message": "基于 Kubernetes 生态构建",
+    "description": "Introductory label for homepage ecosystem integrations"
+  },
+  "homepage.features.eyebrow": {
+    "message": "为何选择 FUSIONINFER",
+    "description": "Eyebrow label for the homepage features section"
+  },
+  "homepage.features.heading": {
+    "message": "一个控制平面，覆盖多种服务拓扑",
+    "description": "Heading for the homepage features section"
+  },
+  "homepage.features.intro": {
+    "message": "保持面向用户的 API 简洁，由 FusionInfer 协调现代推理所需的 Kubernetes 资源。",
+    "description": "Introductory text for the homepage features section"
+  },
+  "homepage.workflows.eyebrow": {
+    "message": "为平台团队而构建",
+    "description": "Eyebrow label for the homepage workflows section"
+  },
+  "homepage.workflows.heading": {
+    "message": "清晰易读的声明式工作流",
+    "description": "Heading for the homepage workflows section"
+  },
+  "homepage.workflows.tabListAriaLabel": {
+    "message": "推理工作流",
+    "description": "Accessible label for the homepage workflow tabs"
+  },
+  "homepage.workflows.deploymentGuideCta": {
+    "message": "阅读部署指南",
+    "description": "Link label for the deployment guide from the workflows section"
+  },
+  "homepage.architecture.outputs.requestScheduling": {
+    "message": "请求调度",
+    "description": "Purpose of Endpoint Picker in the architecture diagram"
+  },
+  "homepage.architecture.outputs.distributedReplicas": {
+    "message": "分布式副本",
+    "description": "Purpose of LeaderWorkerSet in the architecture diagram"
+  },
+  "homepage.architecture.outputs.gangScheduling": {
+    "message": "Gang 调度",
+    "description": "Purpose of PodGroup in the architecture diagram"
+  },
+  "homepage.architecture.eyebrow": {
+    "message": "架构",
+    "description": "Eyebrow label for the homepage architecture section"
+  },
+  "homepage.architecture.heading": {
+    "message": "以紧凑 API 封装生产级基础组件",
+    "description": "Heading for the homepage architecture section"
+  },
+  "homepage.architecture.description": {
+    "message": "FusionInfer 显式绑定 Model、RuntimeProfile 和 InferenceDeployment 资源，随后调和模型下载与缓存、工作负载、调度与路由。",
+    "description": "Description of the FusionInfer architecture on the homepage"
+  },
+  "homepage.architecture.designCta": {
+    "message": "探索设计",
+    "description": "Link label for the design documentation from the architecture section"
+  },
+  "homepage.architecture.controllerPurpose": {
+    "message": "调和期望拓扑",
+    "description": "Controller purpose in the homepage architecture diagram"
+  },
+  "homepage.useCases.eyebrow": {
+    "message": "服务拓扑",
+    "description": "Eyebrow label for the homepage serving use cases section"
+  },
+  "homepage.useCases.heading": {
+    "message": "从简单开始，按需扩展至所需拓扑。",
+    "description": "Heading for the homepage serving use cases section"
+  },
+  "homepage.demos.eyebrow": {
+    "message": "真实工作负载",
+    "description": "Eyebrow label for the homepage demos section"
+  },
+  "homepage.demos.heading": {
+    "message": "查看控制平面如何运转",
+    "description": "Heading for the homepage demos section"
+  },
+  "homepage.demos.tabListAriaLabel": {
+    "message": "FusionInfer 演示",
+    "description": "Accessible label for the homepage demo tabs"
+  },
+  "homepage.demos.documentationCta": {
+    "message": "查看文档",
+    "description": "Link label for documentation from the demos section"
+  },
+  "homepage.demos.transcriptSummary": {
+    "message": "此演示展示的内容",
+    "description": "Summary label for a homepage demo transcript"
+  },
+  "homepage.demos.playAriaLabel": {
+    "message": "播放“{title}”",
+    "description": "Accessible label for a homepage demo play button"
+  },
+  "homepage.community.eyebrow": {
+    "message": "开放共建",
+    "description": "Eyebrow label for the homepage community section"
+  },
+  "homepage.community.heading": {
+    "message": "共同塑造下一代 LLM 服务。",
+    "description": "Heading for the homepage community section"
+  },
+  "homepage.community.description": {
+    "message": "探索控制器、阅读设计决策，并帮助推动 Kubernetes 原生推理编排演进。",
+    "description": "Description of the homepage community section"
+  },
+  "homepage.community.documentationCta": {
+    "message": "阅读文档",
+    "description": "Link label for documentation from the community section"
+  },
+  "homepage.seo.title": {
+    "message": "Kubernetes 原生 LLM 推理平台",
+    "description": "SEO title for the FusionInfer homepage"
+  },
+  "homepage.seo.description": {
+    "message": "FusionInfer 在 Kubernetes 上编排一体式、Prefill/Decode 和多节点 LLM 推理。",
+    "description": "SEO description for the FusionInfer homepage"
+  }
+}

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-blog/2026-07-25-introducing-fusioninfer.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-blog/2026-07-25-introducing-fusioninfer.md
@@ -58,7 +58,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args: ["--model", "Qwen/Qwen3-8B"]
               resources:
                 limits:

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-blog/2026-07-25-introducing-fusioninfer.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-blog/2026-07-25-introducing-fusioninfer.md
@@ -1,0 +1,88 @@
+---
+slug: introducing-fusioninfer
+title: "推出 FusionInfer：面向 LLM 推理的 Kubernetes 原生平台"
+authors: [fusioninfer-team]
+tags: [kubernetes, llm-inference, platform-engineering]
+description: 了解 FusionInfer——一个以声明式方式编排 LLM 推理的 Kubernetes 原生平台。
+---
+
+运行 LLM 推理引擎只是生产环境中提供模型服务的一环。平台团队还必须协调分布式工作负载、对使用 GPU 的 Pod 进行协同调度，并依据推理特有的信号路由请求。
+
+FusionInfer 将这些职责统一到一个 Kubernetes API 之下。
+
+<!-- truncate -->
+
+## 一个声明式 API {#one-declarative-api}
+
+FusionInfer 提供 `InferenceService` 自定义资源，用于描述推理拓扑。一个服务可以在一份清单中组合工作负载角色、副本数量、多节点设置、Pod 模板和路由配置。
+
+控制器将这份声明转换为所选拓扑所需的 Kubernetes 资源，包括：
+
+- 用于推理工作负载的 `LeaderWorkerSet` 资源
+- 用于 Gang 调度的 Volcano `PodGroup` 资源
+- 用于推理感知流量管理的 `InferencePool` 和 `HTTPRoute` 资源
+
+这样既能让面向用户的工作流保持 Kubernetes 原生，又能让推理引擎继续运行在工作负载容器内。
+
+## 三种服务拓扑 {#three-serving-topologies}
+
+FusionInfer 围绕三种 LLM 服务模式而设计：
+
+1. **一体式服务**在单一推理角色内完成请求的整个生命周期。
+2. **Prefill/Decode 分离**将计算密集型的 Prefill 阶段与内存密集型的 Decode 阶段分开。
+3. **多节点推理**在模型必须跨多个节点运行时采用 Leader/Worker 拓扑。
+
+每种拓扑都使用相同的 `InferenceService` API，因此团队无需为每种服务模式采用不同的编排模型。
+
+## 熟悉的 Kubernetes 工作流 {#a-familiar-kubernetes-workflow}
+
+下面的精简示例声明了一个启用路由的单节点服务：
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen
+spec:
+  roles:
+    - name: router
+      componentType: router
+      strategy: prefix-cache
+      httproute:
+        parentRefs:
+          - name: inference-gateway
+    - name: inference
+      componentType: worker
+      replicas: 2
+      template:
+        spec:
+          containers:
+            - name: vllm
+              image: vllm/vllm-openai:v0.26.0
+              args: ["--model", "Qwen/Qwen3-8B"]
+              resources:
+                limits:
+                  nvidia.com/gpu: "1"
+```
+
+用户可以使用标准 Kubernetes 工具提交该清单。随后，FusionInfer 会调和该服务所表示的工作负载和路由资源。
+
+## 推理感知路由 {#inference-aware-routing}
+
+通用负载均衡无法考虑前缀复用、KV cache 压力、队列深度，以及 Prefill 与 Decode 的分离等信号。FusionInfer 的 `InferenceService` API 提供以下路由策略：
+
+- Prefix cache 感知
+- KV cache 利用率
+- 队列大小
+- LoRA 亲和性
+- Prefill/Decode 分离
+
+预定义策略不足时，高级用户还可以提供 `EndpointPickerConfig`。
+
+## 平台，而非推理引擎 {#a-platform-not-an-inference-engine}
+
+FusionInfer 不负责模型执行。vLLM 等引擎仍然在工作负载容器中运行。FusionInfer 专注于这些引擎周围的 Kubernetes 控制平面，目前的范围是 LLM 推理，而非通用机器学习工作负载。
+
+## 开始探索 {#start-exploring}
+
+阅读[文档](/docs/intro)以了解架构和前置要求，然后按照[部署指南](/docs/user-guide/deployment)完成单节点和多节点示例。

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-blog/authors.yml
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-blog/authors.yml
@@ -1,0 +1,7 @@
+fusioninfer-team:
+  name: FusionInfer Team
+  title: FusionInfer 维护者
+  url: https://github.com/fusioninfer
+  image_url: /img/fusioninfer-logo.png
+  socials:
+    github: fusioninfer

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-blog/options.json
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "博客",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "博客",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "所有文章",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-blog/tags.yml
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-blog/tags.yml
@@ -1,0 +1,14 @@
+kubernetes:
+  label: Kubernetes
+  permalink: /kubernetes
+  description: 关于 Kubernetes 原生编排与基础设施的内容。
+
+llm-inference:
+  label: LLM 推理
+  permalink: /llm-inference
+  description: 关于大语言模型推理与服务的内容。
+
+platform-engineering:
+  label: 平台工程
+  permalink: /platform-engineering
+  description: 关于构建和运维推理平台的内容。

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,22 @@
+{
+  "version.label": {
+    "message": "下一版本",
+    "description": "The label for version current"
+  },
+  "sidebar.tutorialSidebar.category.getting-started": {
+    "message": "入门",
+    "description": "The label for category 'Getting Started' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.user-guide": {
+    "message": "用户指南",
+    "description": "The label for category 'User Guide' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.design": {
+    "message": "设计",
+    "description": "The label for category 'Design' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.developer-guide": {
+    "message": "开发者指南",
+    "description": "The label for category 'Developer Guide' in sidebar 'tutorialSidebar'"
+  }
+}

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/core-design.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/core-design.md
@@ -3,41 +3,41 @@ sidebar_position: 1
 title: InferenceService CRD
 ---
 
-:::warning Legacy API design
-This page documents the existing `InferenceService` v1alpha1 API and Controller behavior. It remains relevant during migration, but the target user API is described by [Architecture](./model-serving.md). The current multi-node, LeaderWorkerSet, and Volcano design is documented separately in [Workload Orchestration](./workload-orchestration.md); the sections below retain the legacy `InferenceService.roles` terminology.
-:::
+:::warning 旧版 API 设计
+本文档说明现有 `InferenceService` v1alpha1 API 和 Controller 行为。迁移期间本文档仍有参考价值，但目标用户 API 见[架构](./model-serving.md)。当前的多节点、LeaderWorkerSet 和 Volcano 设计另见[工作负载编排](./workload-orchestration.md)；以下章节保留旧版 `InferenceService.roles` 术语。
+::::
 
 # InferenceService CRD {#inferenceservice-crd}
 
-## Summary {#summary}
+## 概述 {#summary}
 
-This proposal introduces a `InferenceService` CRD to support both **monolithic** and **prefill/decode (PD) disaggregated** serving topologies for large language models (LLMs). The design enables users to declaratively define:
+本方案引入一个 `InferenceService` CRD，以同时支持大型语言模型（LLM）的**单体**和 **Prefill/Decode（PD）分离**服务拓扑。该设计让用户能够以声明方式定义：
 
-- Role-specific deployments (`router`, `prefiller`, `decoder`, `worker`)
-- Scheduling policies through a pluggable request scheduling framework
-- Multi-node replication and resource constraints per role
+- 按角色划分的部署（`router`、`prefiller`、`decoder`、`worker`）
+- 通过可插拔请求调度框架配置的调度策略
+- 每个角色的多节点副本和资源约束
 
-## Motivation {#motivation}
+## 动机 {#motivation}
 
-Modern LLM serving systems increasingly adopt **disaggregation** (separating prefill and decode role) to improve GPU utilization, reduce latency tail, and enable independent scaling. However, many use cases still benefit from **monolithic deployment** (single pod handling full request lifecycle) due to simplicity or low traffic.
+现代 LLM 服务系统越来越多地采用**分离**架构（将 Prefill 和 Decode 角色分开），以提高 GPU 利用率、降低尾延迟并支持独立扩缩容。但是，许多使用场景仍受益于**单体部署**（由单个 Pod 处理完整请求生命周期），因为它更简单或适合低流量。
 
-### Goals {#goals}
+### 目标 {#goals}
 
-- Define a single CRD that supports both monolithic and disaggregated inference topologies.
-- Allow per component specification of replicas, node count, container templates, and resources.
-- Integrate with an **EPP scheduling framework** for request scheduling at the gateway.
-- Enable multi-node deployment for prefill/decode components to scale across GPUs/nodes.
+- 定义一个同时支持单体和分离推理拓扑的 CRD。
+- 允许为每个组件指定副本数、节点数、容器模板和资源。
+- 与用于 Gateway 请求调度的 **EPP 调度框架**集成。
+- 支持 Prefill/Decode 组件的多节点部署，以跨 GPU/节点扩展。
 
-### Non-Goals {#non-goals}
+### 非目标 {#non-goals}
 
-- Implement the underlying inference engine (e.g., vLLM, TensorRT-LLM) — only orchestrate it.
-- Support non-LLM workloads.
+- 实现底层推理引擎（例如 vLLM、TensorRT-LLM）——本方案只负责编排。
+- 支持非 LLM 工作负载。
 
-## User Stories {#user-stories}
+## 用户故事 {#user-stories}
 
-### Story 1: Deploy a monolithic LLM service {#story-1-deploy-a-monolithic-llm-service}
+### 故事 1：部署单体 LLM 服务 {#story-1-deploy-a-monolithic-llm-service}
 
-As a developer, I want to deploy Qwen-3 as a single-service endpoint.
+作为开发者，我希望将 Qwen-3 部署为单服务端点。
 
 ```yaml
 apiVersion: fusioninfer.io/v1alpha1
@@ -65,9 +65,9 @@ spec:
                   nvidia.com/gpu: "1"
 ```
 
-### Story 2: Deploy a disaggregated prefill/decode service {#story-2-deploy-a-disaggregated-prefilldecode-service}
+### 故事 2：部署 Prefill/Decode 分离服务 {#story-2-deploy-a-disaggregated-prefilldecode-service}
 
-As a developer, I want to deploy a prefill/decode disaggregated inference service for Qwen-3.
+作为开发者，我希望为 Qwen-3 部署 Prefill/Decode 分离推理服务。
 
 ```yaml
 apiVersion: fusioninfer.io/v1alpha1
@@ -116,9 +116,9 @@ spec:
                   nvidia.com/gpu: "1"
 ```
 
-### Story 3: Deploy a multi-node inference service for large models {#story-3-deploy-a-multi-node-inference-service-for-large-models}
+### 故事 3：为大模型部署多节点推理服务 {#story-3-deploy-a-multi-node-inference-service-for-large-models}
 
-As a developer, I want to deploy DeepSeek-R1 (671B) using multi-node tensor parallelism. System deploys 2 replicas × 4 nodes = 8 pods, each with 8 GPUs (total 64 GPUs for tensor parallelism).
+作为开发者，我希望使用多节点张量并行部署 DeepSeek-R1（671B）。系统将部署 2 个副本 × 4 个节点 = 8 个 Pod，每个 Pod 使用 8 张 GPU（张量并行共使用 64 张 GPU）。
 
 ```yaml
 apiVersion: fusioninfer.io/v1alpha1
@@ -150,9 +150,9 @@ spec:
                   nvidia.com/gpu: "8"
 ```
 
-### Story 4: Deploy a disaggregated multi-node prefill/decode service {#story-4-deploy-a-disaggregated-multi-node-prefilldecode-service}
+### 故事 4：部署 Prefill/Decode 分离的多节点服务 {#story-4-deploy-a-disaggregated-multi-node-prefilldecode-service}
 
-As a developer, I want to deploy DeepSeek-R1 with prefill/decode disaggregation and multi-node parallelism. System deploys prefill (1 replica × 2 nodes = 2 pods) + decode (2 replicas × 4 nodes = 8 pods), total 10 pods with 80 GPUs.
+作为开发者，我希望使用 Prefill/Decode 分离和多节点并行部署 DeepSeek-R1。系统将部署 Prefill（1 个副本 × 2 个节点 = 2 个 Pod）+ Decode（2 个副本 × 4 个节点 = 8 个 Pod），共 10 个 Pod、80 张 GPU。
 
 ```yaml
 apiVersion: fusioninfer.io/v1alpha1
@@ -209,27 +209,27 @@ spec:
                   nvidia.com/gpu: "8"
 ```
 
-## Proposal {#proposal}
+## 方案 {#proposal}
 
-The `InferenceService` CR will serve as the primary user-facing API for LLM deployment. 
-Users declare **roles** (a list of components), each identified by a user-chosen name and classified by its componentType.
+`InferenceService` CR 将作为面向用户的主要 LLM 部署 API。
+用户声明 **roles**（组件列表），每个角色由用户选择的名称标识，并按其 `componentType` 分类。
 
-### Component Types {#component-types}
+### 组件类型 {#component-types}
 
-| componentType | Description |
-|---------------|-------------|
-| `worker` | Monolithic inference (full request lifecycle) |
-| `prefiller` | Handles prompt ingestion and KV cache generation |
-| `decoder` | Performs autoregressive token generation |
-| `router` | Request router with EPP scheduling plugins |
+| componentType | 说明 |
+|---------------|------|
+| `worker` | 单体推理（完整请求生命周期） |
+| `prefiller` | 处理 prompt 摄入和 KV cache 生成 |
+| `decoder` | 执行自回归 token 生成 |
+| `router` | 使用 EPP 调度插件的请求路由器 |
 
-### Reconciliation Logic {#reconciliation-logic}
+### 调和逻辑 {#reconciliation-logic}
 
-The following diagrams illustrate the resource topology for different deployment scenarios.
+以下图示说明不同部署场景的资源拓扑。
 
-#### Monolithic Deployment {#monolithic-deployment}
+#### 单体部署 {#monolithic-deployment}
 
-A simple single-role deployment where each pod handles the full inference lifecycle.
+简单的单角色部署，每个 Pod 处理完整的推理生命周期。
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -239,7 +239,7 @@ A simple single-role deployment where each pod handles the full inference lifecy
                           │
                           ▼
               ┌───────────────────────┐
-              │    Role: inference    │
+              │    角色: inference    │
               │  componentType: worker│
               │     replicas: 1       │
               └───────────┬───────────┘
@@ -250,15 +250,15 @@ A simple single-role deployment where each pod handles the full inference lifecy
                   │  (size=1)     │
                   ├───────────────┤
                   │  ★ Leader-0   │
-                  │    [1 GPU]    │
+                  │   [1 张 GPU]  │
                   └───────────────┘
 
-      Total: 1 replica × 1 node × 1 GPU = 1 GPU
+      总计：1 个副本 × 1 个节点 × 1 张 GPU = 1 张 GPU
 ```
 
-#### Disaggregated PD Deployment {#disaggregated-pd-deployment}
+#### Prefill/Decode 分离部署 {#disaggregated-pd-deployment}
 
-Prefill and decode are separated into independent roles for better resource utilization.
+Prefill 和 Decode 被拆分为独立角色，以提高资源利用率。
 
 ```
 ┌───────────────────────────────────────────────────────────────────────────┐
@@ -267,14 +267,14 @@ Prefill and decode are separated into independent roles for better resource util
 └─────────────────────────────────┬─────────────────────────────────────────┘
                                   │
                   ┌───────────────┴───────────────┐
-                  │         Roles (2)             │
+                  │          角色 (2)             │
                   └───────────────┬───────────────┘
                                   │
          ┌────────────────────────┼────────────────────────┐
          │                                                 │
          ▼                                                 ▼
 ┌─────────────────────┐                       ┌─────────────────────┐
-│   Role: prefill     │                       │   Role: decode      │
+│   角色: prefill     │                       │   角色: decode      │
 │ componentType:      │                       │ componentType:      │
 │   prefiller         │                       │   decoder           │
 │ replicas: 2         │                       │ replicas: 4         │
@@ -287,21 +287,21 @@ Prefill and decode are separated into independent roles for better resource util
   │  replicas: 2  │                           │  replicas: 4  │
   ├───────────────┤                           ├───────────────┤
   │  ★ Leader-0   │                           │  ★ Leader-0   │
-  │    [1 GPU]    │                           │    [1 GPU]    │
+  │   [1 张 GPU]  │                           │   [1 张 GPU]  │
   │  ★ Leader-1   │                           │  ★ Leader-1   │
-  │    [1 GPU]    │                           │    [1 GPU]    │
+  │   [1 张 GPU]  │                           │   [1 张 GPU]  │
   └───────────────┘                           │  ★ Leader-2   │
-                                              │    [1 GPU]    │
+                                              │   [1 张 GPU]  │
                                               │  ★ Leader-3   │
-                                              │    [1 GPU]    │
+                                              │   [1 张 GPU]  │
                                               └───────────────┘
 
-      Total: prefill (2 × 1 GPU) + decode (4 × 1 GPU) = 6 GPUs
+      总计：Prefill（2 × 1 张 GPU）+ Decode（4 × 1 张 GPU）= 6 张 GPU
 ```
 
-#### Multi-Node Deployment {#multi-node-deployment}
+#### 多节点部署 {#multi-node-deployment}
 
-Large model deployment using LeaderWorkerSet (LWS) for multi-node tensor parallelism.
+使用 LeaderWorkerSet（LWS）进行多节点张量并行的大模型部署。
 
 ```
 ┌───────────────────────────────────────────────────────────────────────────┐
@@ -311,7 +311,7 @@ Large model deployment using LeaderWorkerSet (LWS) for multi-node tensor paralle
                                   │
                                   ▼
                       ┌───────────────────────┐
-                      │    Role: inference    │
+                      │    角色: inference    │
                       │  componentType: worker│
                       │     replicas: 2       │
                       │  multinode:           │
@@ -323,26 +323,26 @@ Large model deployment using LeaderWorkerSet (LWS) for multi-node tensor paralle
                 ▼                                   ▼
       ┌─────────────────────┐             ┌─────────────────────┐
       │  LeaderWorkerSet-0  │             │  LeaderWorkerSet-1  │
-      │     (4 Pods)        │             │     (4 Pods)        │
-      │   TP=32 across      │             │   TP=32 across      │
-      │   32 GPUs           │             │   32 GPUs           │
+      │     (4 个 Pod)      │             │     (4 个 Pod)      │
+      │   TP=32，跨         │             │   TP=32，跨         │
+      │   32 张 GPU         │             │   32 张 GPU         │
       ├─────────────────────┤             ├─────────────────────┤
       │ ★ Leader Pod-0      │             │ ★ Leader Pod-0      │
-      │   [8 GPUs]          │             │   [8 GPUs]          │
+      │   [8 张 GPU]        │             │   [8 张 GPU]        │
       │ ● Worker Pod-1      │             │ ● Worker Pod-1      │
-      │   [8 GPUs]          │             │   [8 GPUs]          │
+      │   [8 张 GPU]        │             │   [8 张 GPU]        │
       │ ● Worker Pod-2      │             │ ● Worker Pod-2      │
-      │   [8 GPUs]          │             │   [8 GPUs]          │
+      │   [8 张 GPU]        │             │   [8 张 GPU]        │
       │ ● Worker Pod-3      │             │ ● Worker Pod-3      │
-      │   [8 GPUs]          │             │   [8 GPUs]          │
+      │   [8 张 GPU]        │             │   [8 张 GPU]        │
       └─────────────────────┘             └─────────────────────┘
 
-      Total: inference (2 replicas × 4 nodes × 8 GPUs) = 8 pods, 64 GPUs
+      总计：inference（2 个副本 × 4 个节点 × 8 张 GPU）= 8 个 Pod、64 张 GPU
 ```
 
-#### Disaggregated Multi-Node Deployment {#disaggregated-multi-node-deployment}
+#### Prefill/Decode 分离多节点部署 {#disaggregated-multi-node-deployment}
 
-Combines prefill/decode disaggregation with multi-node parallelism for maximum scalability.
+将 Prefill/Decode 分离与多节点并行相结合，以获得最大的可扩展性。
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────────────────┐
@@ -351,14 +351,14 @@ Combines prefill/decode disaggregation with multi-node parallelism for maximum s
 └────────────────────────────────────────────┬────────────────────────────────────────────┘
                                              │
                               ┌──────────────┴──────────────┐
-                              │          Roles (2)          │
+                              │          角色 (2)           │
                               └──────────────┬──────────────┘
                                              │
                  ┌───────────────────────────┴───────────────────────────┐
                  │                                                       │
                  ▼                                                       ▼
 ┌───────────────────────────┐                           ┌───────────────────────────┐
-│      Role: prefill        │                           │      Role: decode         │
+│      角色: prefill        │                           │      角色: decode         │
 │  componentType: prefiller │                           │  componentType: decoder   │
 │  replicas: 1              │                           │  replicas: 2              │
 │  multinode:               │                           │  multinode:               │
@@ -368,96 +368,96 @@ Combines prefill/decode disaggregation with multi-node parallelism for maximum s
               ▼                                           ┌───────────┴───────────┐
 ┌─────────────────────────┐                               │                       │
 │    LeaderWorkerSet-0    │                               ▼                       ▼
-│       (2 Pods)          │                 ┌───────────────────────┐ ┌───────────────────────┐
-│    TP=16 across         │                 │   LeaderWorkerSet-0   │ │   LeaderWorkerSet-1   │
-│    16 GPUs              │                 │       (4 Pods)        │ │       (4 Pods)        │
-├─────────────────────────┤                 │    TP=32 across       │ │    TP=32 across       │
-│  ★ Leader Pod-0         │                 │    32 GPUs            │ │    32 GPUs            │
-│    [8 GPUs]             │                 ├───────────────────────┤ ├───────────────────────┤
+│       (2 个 Pod)        │                 ┌───────────────────────┐ ┌───────────────────────┐
+│    TP=16，跨            │                 │   LeaderWorkerSet-0   │ │   LeaderWorkerSet-1   │
+│    16 张 GPU            │                 │       (4 个 Pod)      │ │       (4 个 Pod)      │
+├─────────────────────────┤                 │    TP=32，跨          │ │    TP=32，跨          │
+│  ★ Leader Pod-0         │                 │    32 张 GPU          │ │    32 张 GPU          │
+│    [8 张 GPU]           │                 ├───────────────────────┤ ├───────────────────────┤
 │  ● Worker Pod-1         │                 │  ★ Leader Pod-0       │ │  ★ Leader Pod-0       │
-│    [8 GPUs]             │                 │    [8 GPUs]           │ │    [8 GPUs]           │
+│    [8 张 GPU]           │                 │    [8 张 GPU]         │ │    [8 张 GPU]         │
 └─────────────────────────┘                 │  ● Worker Pod-1       │ │  ● Worker Pod-1       │
-                                            │    [8 GPUs]           │ │    [8 GPUs]           │
+                                            │    [8 张 GPU]         │ │    [8 张 GPU]         │
                                             │  ● Worker Pod-2       │ │  ● Worker Pod-2       │
-                                            │    [8 GPUs]           │ │    [8 GPUs]           │
+                                            │    [8 张 GPU]         │ │    [8 张 GPU]         │
                                             │  ● Worker Pod-3       │ │  ● Worker Pod-3       │
-                                            │    [8 GPUs]           │ │    [8 GPUs]           │
+                                            │    [8 张 GPU]         │ │    [8 张 GPU]         │
                                             └───────────────────────┘ └───────────────────────┘
 
-      Total: prefill (1 × 2 nodes × 8 GPUs) + decode (2 × 4 nodes × 8 GPUs) = 16 + 64 = 80 GPUs
+      总计：Prefill（1 × 2 个节点 × 8 张 GPU）+ Decode（2 × 4 个节点 × 8 张 GPU）= 16 + 64 = 80 张 GPU
 ```
 
-### LeaderWorkerSet (LWS) Workload Management {#leaderworkerset-lws-workload-management}
+### LeaderWorkerSet（LWS）工作负载管理 {#leaderworkerset-lws-workload-management}
 
-The controller uses **LeaderWorkerSet (LWS)** for all deployments to provide unified workload management and gang scheduling support.
+Controller 对所有部署使用 **LeaderWorkerSet（LWS）**，以提供统一的工作负载管理和 Gang Scheduling 支持。
 
-| Configuration | LWS Mode | LWS Size | Scheduler | Description |
-|---------------|----------|----------|-----------|-------------|
-| `multinode` not set | Per-replica | `size: 1` | default | Single pod per replica |
-| `multinode.nodeCount >= 2` (monolithic) | Per-replica | `size: nodeCount` | volcano | One LWS per replica for independent scheduling |
-| PD disaggregated | Per-replica | `size: nodeCount` | volcano | Shared PodGroup across prefill/decode roles |
+| 配置 | LWS 模式 | LWS 大小 | 调度器 | 说明 |
+|------|----------|----------|--------|------|
+| 未设置 `multinode` | 每副本 | `size: 1` | default | 每个副本一个 Pod |
+| `multinode.nodeCount >= 2`（单体） | 每副本 | `size: nodeCount` | volcano | 每个副本一个 LWS，以便独立调度 |
+| PD 分离 | 每副本 | `size: nodeCount` | volcano | Prefill/Decode 角色共享 PodGroup |
 
-**LWS Mode:**
+**LWS 模式：**
 
-The controller always uses **Per-replica mode** (one LWS per replica) to support fine-grained scaling and cleanup.
+Controller 始终使用**每副本模式**（每个副本一个 LWS），以支持细粒度扩缩容和清理。
 
-| Mode | LWS Count | PodGroup Count | Use Case |
-|------|-----------|----------------|----------|
-| **Per-replica** | N per role (one per replica) | 1 shared (if gang scheduling needed) | All deployment scenarios |
+| 模式 | LWS 数量 | PodGroup 数量 | 使用场景 |
+|------|----------|---------------|----------|
+| **每副本** | 每个角色 N 个（每个副本一个） | 1 个共享 PodGroup（如果需要 Gang Scheduling） | 所有部署场景 |
 
-**Labels injected by Controller:**
+**Controller 注入的 Label：**
 
-| Label | Description |
-|-------|-------------|
-| `fusioninfer.io/service` | InferenceService name |
-| `fusioninfer.io/component-type` | Component type (worker/prefiller/decoder) |
-| `fusioninfer.io/role-name` | Role name from spec |
-| `fusioninfer.io/replica-index` | Replica index (only in per-replica mode) |
-| `fusioninfer.io/spec-hash` | Hash of resource spec for change detection |
+| Label | 说明 |
+|-------|------|
+| `fusioninfer.io/service` | InferenceService 名称 |
+| `fusioninfer.io/component-type` | 组件类型（worker/prefiller/decoder） |
+| `fusioninfer.io/role-name` | spec 中的角色名称 |
+| `fusioninfer.io/replica-index` | 副本索引（仅限每副本模式） |
+| `fusioninfer.io/spec-hash` | 用于变更检测的资源 spec 哈希值 |
 
-**Naming Convention:**
+**命名约定：**
 
-The complete naming chain from InferenceService to Pods:
+从 InferenceService 到 Pod 的完整命名链如下：
 
 ```
 InferenceService: <service-name>
          │
-         ▼ (Controller creates)
+         ▼（Controller 创建）
 LWS: <service>-<role>-<fusioninfer-replica>
          │
-         ▼ (LWS creates)
-Pods:
-  ├── <lws-name>-<lws-replica>              (Leader, no worker suffix)
-  └── <lws-name>-<lws-replica>-<worker>     (Workers, index starts from 1)
+         ▼（LWS 创建）
+Pod：
+  ├── <lws-name>-<lws-replica>              （Leader，无 worker 后缀）
+  └── <lws-name>-<lws-replica>-<worker>     （Worker，索引从 1 开始）
 ```
 
-| Resource | Naming Pattern | Example |
-|----------|----------------|---------|
+| 资源 | 命名模式 | 示例 |
+|------|----------|------|
 | LWS | `{service}-{role}-{replica}` | `qwen-inference-inference-0` |
 | Leader Pod | `{lws-name}-{lws-replica}` | `qwen-inference-inference-0-0` |
 | Worker Pod | `{lws-name}-{lws-replica}-{worker}` | `qwen-inference-inference-0-0-1` |
 
-> **Note**: The Leader pod does not have a worker index suffix. Worker pods have indices starting from 1.
+> **注意**：Leader Pod 没有 worker 索引后缀。Worker Pod 的索引从 1 开始。
 
-**Example: Pod Naming for Multi-Node Deployment**
+**示例：多节点部署的 Pod 命名**
 
-For an InferenceService named `deepseek-r1` with role `inference`, `replicas: 2`, and `nodeCount: 4`:
+对于名为 `deepseek-r1`、角色为 `inference`、`replicas: 2` 且 `nodeCount: 4` 的 InferenceService：
 
 ```
-deepseek-r1-inference-0          (LWS for replica 0)
-  ├── deepseek-r1-inference-0-0      (Leader)
-  ├── deepseek-r1-inference-0-0-1    (Worker 1)
-  ├── deepseek-r1-inference-0-0-2    (Worker 2)
-  └── deepseek-r1-inference-0-0-3    (Worker 3)
+deepseek-r1-inference-0          （副本 0 的 LWS）
+  ├── deepseek-r1-inference-0-0      （Leader）
+  ├── deepseek-r1-inference-0-0-1    （Worker 1）
+  ├── deepseek-r1-inference-0-0-2    （Worker 2）
+  └── deepseek-r1-inference-0-0-3    （Worker 3）
 
-deepseek-r1-inference-1          (LWS for replica 1)
-  ├── deepseek-r1-inference-1-0      (Leader)
-  ├── deepseek-r1-inference-1-0-1    (Worker 1)
-  ├── deepseek-r1-inference-1-0-2    (Worker 2)
-  └── deepseek-r1-inference-1-0-3    (Worker 3)
+deepseek-r1-inference-1          （副本 1 的 LWS）
+  ├── deepseek-r1-inference-1-0      （Leader）
+  ├── deepseek-r1-inference-1-0-1    （Worker 1）
+  ├── deepseek-r1-inference-1-0-2    （Worker 2）
+  └── deepseek-r1-inference-1-0-3    （Worker 3）
 ```
 
-**Example 1: Single-Node LWS**
+**示例 1：单节点 LWS**
 
 ```yaml
 apiVersion: leaderworkerset.x-k8s.io/v1
@@ -467,7 +467,7 @@ metadata:
 spec:
   replicas: 2
   leaderWorkerTemplate:
-    size: 1                    # Single pod per replica
+    size: 1                    # 每个副本一个 Pod
     workerTemplate:
       spec:
         containers:
@@ -481,16 +481,16 @@ spec:
                 nvidia.com/gpu: "1"
 ```
 
-**Example 2: Multi-Node LWS with Gang Scheduling**
+**示例 2：使用 Gang Scheduling 的多节点 LWS**
 
-For multi-node deployments (`replicas: 2, nodeCount: 4`), the **InferenceService Controller** creates:
-- **1 shared PodGroup** with `minTaskMember` for each replica
-- **Separate LWS per replica** to enable fine-grained scheduling
+对于多节点部署（`replicas: 2, nodeCount: 4`），**InferenceService Controller** 会创建：
+- **1 个共享 PodGroup**，其中包含每个副本的 `minTaskMember`
+- **每个副本独立的 LWS**，以支持细粒度调度
 
 ```
-InferenceService (replicas: 2, nodeCount: 4)
+InferenceService（replicas: 2, nodeCount: 4）
     │
-    ├── PodGroup: deepseek-r1-inference (shared)
+    ├── PodGroup: deepseek-r1-inference（共享）
     │   └── minTaskMember: {inference-0: 4, inference-1: 4}
     │
     ├── LWS: deepseek-r1-inference-inference-0
@@ -500,21 +500,21 @@ InferenceService (replicas: 2, nodeCount: 4)
         └── replicas: 1, size: 4, task-spec: inference-1
 ```
 
-This allows partial deployment when cluster resources are limited (e.g., only one replica can be scheduled).
+这样可在集群资源有限时进行部分部署（例如只能调度一个副本）。
 
 ```yaml
-# Shared PodGroup for the InferenceService
+# InferenceService 的共享 PodGroup
 apiVersion: scheduling.volcano.sh/v1beta1
 kind: PodGroup
 metadata:
   name: deepseek-r1-inference
 spec:
-  minMember: 8                       # 4 + 4 = 8 pods total
+  minMember: 8                       # 4 + 4 = 共 8 个 Pod
   minTaskMember:
-    inference-0: 4                   # All 4 pods in replica 0
-    inference-1: 4                   # All 4 pods in replica 1
+    inference-0: 4                   # 副本 0 中的全部 4 个 Pod
+    inference-1: 4                   # 副本 1 中的全部 4 个 Pod
 ---
-# Per-replica LWS (Controller creates one for each replica)
+# 每副本 LWS（Controller 为每个副本创建一个）
 apiVersion: leaderworkerset.x-k8s.io/v1
 kind: LeaderWorkerSet
 metadata:
@@ -525,10 +525,10 @@ metadata:
     fusioninfer.io/role-name: inference
     fusioninfer.io/replica-index: "0"
 spec:
-  replicas: 1                         # Always 1 in per-replica mode
+  replicas: 1                         # 每副本模式中始终为 1
   leaderWorkerTemplate:
-    size: 4                           # 4 pods per replica
-    # LeaderTemplate: Leader starts Ray head and runs vLLM
+    size: 4                           # 每个副本 4 个 Pod
+    # leaderTemplate：Leader 启动 Ray head 并运行 vLLM
     leaderTemplate:
       metadata:
         labels:
@@ -550,7 +550,7 @@ spec:
             resources:
               limits:
                 nvidia.com/gpu: "8"
-    # WorkerTemplate: Workers join Ray cluster
+    # workerTemplate：Worker 加入 Ray 集群
     workerTemplate:
       metadata:
         labels:
@@ -571,79 +571,79 @@ spec:
                 nvidia.com/gpu: "8"
 ```
 
-> **Note**: For multi-node deployments, the Controller automatically generates separate `leaderTemplate` and `workerTemplate`:
-> - **Leader**: `ray start --head && <original command> --distributed-executor-backend ray`
-> - **Worker**: `ray start --address=$LWS_LEADER_ADDRESS:6379 --block`
+> **注意**：对于多节点部署，Controller 会自动生成独立的 `leaderTemplate` 和 `workerTemplate`：
+> - **Leader**：`ray start --head && <original command> --distributed-executor-backend ray`
+> - **Worker**：`ray start --address=$LWS_LEADER_ADDRESS:6379 --block`
 
-### Gang Scheduling Behavior {#gang-scheduling-behavior}
+### Gang Scheduling 行为 {#gang-scheduling-behavior}
 
-The **InferenceService Controller** creates a **single shared PodGroup** per InferenceService. The `minTaskMember` field uses keys in the format `{roleName}-{replicaIndex}` to enable fine-grained gang scheduling that ensures:
+**InferenceService Controller** 为每个 InferenceService 创建**一个共享 PodGroup**。`minTaskMember` 字段使用 `{roleName}-{replicaIndex}` 格式的键，以实现细粒度 Gang Scheduling，并确保：
 
-1. **Intra-replica atomicity**: All pods within a single replica are scheduled together (all-or-nothing)
-2. **Cross-role coordination** (for PD disaggregated): At least one prefill AND one decode replica must be scheduled together
+1. **副本内原子性**：单个副本中的所有 Pod 一起调度（全有或全无）
+2. **跨角色协调**（适用于 PD 分离）：必须至少同时调度一个 Prefill 副本和一个 Decode 副本
 
-| Scenario | LWS Count | PodGroup Count | minTaskMember Keys |
-|----------|-----------|----------------|--------------------|
-| Monolithic (single-node) | 1 per replica | 0 | N/A (no gang scheduling) |
-| Monolithic (multi-node) | 1 per replica | 1 shared | `{role}-0`, `{role}-1`, ... |
-| PD disaggregated | 1 per replica | 1 shared | `prefill-0`, `decode-0`, `decode-1`, ... |
+| 场景 | LWS 数量 | PodGroup 数量 | minTaskMember 键 |
+|------|----------|---------------|-------------------|
+| 单体（单节点） | 每个副本 1 个 | 0 | N/A（无 Gang Scheduling） |
+| 单体（多节点） | 每个副本 1 个 | 1 个共享 PodGroup | `{role}-0`、`{role}-1`，... |
+| PD 分离 | 每个副本 1 个 | 1 个共享 PodGroup | `prefill-0`、`decode-0`、`decode-1`，... |
 
-**Example: PD Disaggregated Multi-Node (Story 4)**
+**示例：PD 分离多节点部署（故事 4）**
 
-For `prefill (1 replica × 2 nodes)` + `decode (2 replicas × 4 nodes)`:
+对于 `Prefill（1 个副本 × 2 个节点）` + `Decode（2 个副本 × 4 个节点）`：
 
 ```yaml
-# Single PodGroup for the entire InferenceService
+# 整个 InferenceService 使用一个 PodGroup
 apiVersion: scheduling.volcano.sh/v1beta1
 kind: PodGroup
 metadata:
   name: deepseek-r1-disagg
 spec:
-  minMember: 10              # 2 + 4 + 4 = 10 pods total
+  minMember: 10              # 2 + 4 + 4 = 共 10 个 Pod
   minTaskMember:
-    prefill-0: 2             # All 2 pods in prefill replica-0
-    decode-0: 4              # All 4 pods in decode replica-0
-    decode-1: 4              # All 4 pods in decode replica-1
+    prefill-0: 2             # Prefill 副本 0 中的全部 2 个 Pod
+    decode-0: 4              # Decode 副本 0 中的全部 4 个 Pod
+    decode-1: 4              # Decode 副本 1 中的全部 4 个 Pod
 ```
 
-**Scheduling Behavior Table:**
+**调度行为表：**
 
-| Cluster GPUs | prefill-0 (16 GPUs) | decode-0 (32 GPUs) | decode-1 (32 GPUs) | Service Status |
-|--------------|---------------------|--------------------|--------------------|----------------|
-| 80 GPUs | ✅ | ✅ | ✅ | Full capacity |
-| 64 GPUs | ✅ | ✅ | ⏳ | Partial (1P + 1D) |
-| 48 GPUs | ✅ | ✅ | ⏳ | Partial (1P + 1D) |
-| 32 GPUs | ⏳ | ⏳ | ⏳ | ❌ Blocked (can't satisfy 1P + 1D atomically) |
-| 16 GPUs | ⏳ | ⏳ | ⏳ | ❌ Blocked (only enough for prefill) |
+| 集群 GPU | prefill-0（16 张 GPU） | decode-0（32 张 GPU） | decode-1（32 张 GPU） | 服务状态 |
+|----------|------------------------|-----------------------|-----------------------|----------|
+| 80 张 GPU | ✅ | ✅ | ✅ | 全部容量 |
+| 64 张 GPU | ✅ | ✅ | ⏳ | 部分可用（1P + 1D） |
+| 48 张 GPU | ✅ | ✅ | ⏳ | 部分可用（1P + 1D） |
+| 32 张 GPU | ⏳ | ⏳ | ⏳ | ❌ 阻塞（无法以原子方式满足 1P + 1D） |
+| 16 张 GPU | ⏳ | ⏳ | ⏳ | ❌ 阻塞（资源只够 Prefill） |
 
-> **Note**: Volcano ensures each task's pods are scheduled atomically. With `minTaskMember`, the scheduler blocks until **all** pods within each task can be scheduled together, preventing partial deployments within a replica.
+> **注意**：Volcano 确保每个任务的 Pod 以原子方式调度。使用 `minTaskMember` 时，调度器会等待，直到任务内的**所有** Pod 都能一起调度，从而避免副本内出现部分部署。
 
-#### PodGroup Management {#podgroup-management}
+#### PodGroup 管理 {#podgroup-management}
 
-The **InferenceService Controller** creates **one PodGroup per InferenceService**. The `minTaskMember` keys use the format `{roleName}-{replicaIndex}` to identify each replica's task:
+**InferenceService Controller** 为**每个 InferenceService 创建一个 PodGroup**。`minTaskMember` 的键使用 `{roleName}-{replicaIndex}` 格式来标识每个副本的任务：
 
 ```yaml
-# PodGroup for PD disaggregated: prefill (2 replicas × 1 node) + decode (4 replicas × 1 node)
+# PD 分离部署的 PodGroup：Prefill（2 个副本 × 1 个节点）+ Decode（4 个副本 × 1 个节点）
 apiVersion: scheduling.volcano.sh/v1beta1
 kind: PodGroup
 metadata:
-  name: qwen3-inference              # Named after InferenceService
+  name: qwen3-inference              # 以 InferenceService 命名
   namespace: default
 spec:
-  minMember: 6                       # 2 + 4 = 6 pods
-  minTaskMember:                     # Matched by pod annotation: volcano.sh/task-spec
-    prefill-0: 1                     # Pods with annotation "volcano.sh/task-spec: prefill-0"
-    prefill-1: 1                     # Pods with annotation "volcano.sh/task-spec: prefill-1"
-    decode-0: 1                      # Pods with annotation "volcano.sh/task-spec: decode-0"
-    decode-1: 1                      # ... and so on
+  minMember: 6                       # 2 + 4 = 6 个 Pod
+  minTaskMember:                     # 通过 Pod annotation volcano.sh/task-spec 匹配
+    prefill-0: 1                     # annotation 为 "volcano.sh/task-spec: prefill-0" 的 Pod
+    prefill-1: 1                     # annotation 为 "volcano.sh/task-spec: prefill-1" 的 Pod
+    decode-0: 1                      # annotation 为 "volcano.sh/task-spec: decode-0" 的 Pod
+    decode-1: 1                      # ... 依此类推
     decode-2: 1
     decode-3: 1
 ```
 
-Each LWS is created per-replica with annotations to join the shared PodGroup:
+每个 LWS 都按副本创建，并通过 annotation 加入共享 PodGroup：
 
 ```yaml
-# Prefill LWS for replica 0 (Controller creates one LWS per replica)
+# 副本 0 的 Prefill LWS（Controller 为每个副本创建一个 LWS）
 apiVersion: leaderworkerset.x-k8s.io/v1
 kind: LeaderWorkerSet
 metadata:
@@ -654,24 +654,24 @@ metadata:
     fusioninfer.io/role-name: prefill
     fusioninfer.io/replica-index: "0"
 spec:
-  replicas: 1                        # Always 1 in per-replica mode
+  replicas: 1                        # 每副本模式中始终为 1
   leaderWorkerTemplate:
-    size: 1                          # 1 pod per replica (single-node)
+    size: 1                          # 每个副本 1 个 Pod（单节点）
     workerTemplate:
       metadata:
         labels:
           fusioninfer.io/replica-index: "0"
         annotations:
-          scheduling.k8s.io/group-name: qwen3-inference   # Join shared PodGroup
-          volcano.sh/task-spec: prefill-0                 # Task: {roleName}-{replicaIndex}
+          scheduling.k8s.io/group-name: qwen3-inference   # 加入共享 PodGroup
+          volcano.sh/task-spec: prefill-0                 # 任务：{roleName}-{replicaIndex}
       spec:
         schedulerName: volcano
         containers:
           - name: vllm
             image: vllm/vllm-openai:v0.26.0
-            # ... prefill config
+            # ... Prefill 配置
 ---
-# Decode LWS for replica 0
+# 副本 0 的 Decode LWS
 apiVersion: leaderworkerset.x-k8s.io/v1
 kind: LeaderWorkerSet
 metadata:
@@ -697,26 +697,26 @@ spec:
         containers:
           - name: vllm
             image: vllm/vllm-openai:v0.26.0
-            # ... decode config
+            # ... Decode 配置
 ```
 
-#### Key Annotations for Volcano Gang Scheduling {#key-annotations-for-volcano-gang-scheduling}
+#### Volcano Gang Scheduling 的关键 Annotation {#key-annotations-for-volcano-gang-scheduling}
 
-| Annotation | Defined In | Purpose |
-|------------|------------|---------|
-| `scheduling.k8s.io/group-name` | `volcano.sh/apis/pkg/apis/scheduling/v1beta1` | Identifies which PodGroup the pod belongs to |
-| `volcano.sh/task-spec` | `volcano.sh/apis/pkg/apis/batch/v1alpha1` | Identifies which task within the PodGroup (matches `minTaskMember` keys) |
+| Annotation | 定义位置 | 用途 |
+|------------|----------|------|
+| `scheduling.k8s.io/group-name` | `volcano.sh/apis/pkg/apis/scheduling/v1beta1` | 标识 Pod 所属的 PodGroup |
+| `volcano.sh/task-spec` | `volcano.sh/apis/pkg/apis/batch/v1alpha1` | 标识 PodGroup 内的任务（与 `minTaskMember` 的键匹配） |
 
-**Task-spec format:** `{roleName}-{replicaIndex}` (e.g., `prefill-0`, `decode-1`)
+**Task-spec 格式：** `{roleName}-{replicaIndex}`（例如 `prefill-0`、`decode-1`）
 
-**References:**
-- [Volcano MinTaskMember Design](https://github.com/volcano-sh/volcano/blob/master/docs/design/task-minavailable.md)
+**参考资料：**
+- [Volcano MinTaskMember 设计](https://github.com/volcano-sh/volcano/blob/master/docs/design/task-minavailable.md)
 - [Volcano Gang Scheduling](https://volcano.sh/en/docs/gang_scheduling/)
 
-### CRD Structure Overview {#crd-structure-overview}
+### CRD 结构概览 {#crd-structure-overview}
 
 ```go
-// ComponentType defines the type of component in the inference pipeline
+// ComponentType 定义推理流水线中的组件类型
 // +kubebuilder:validation:Enum=router;prefiller;decoder;worker
 type ComponentType string
 
@@ -727,127 +727,127 @@ const (
     ComponentTypeWorker    ComponentType = "worker"
 )
 
-// InferenceServiceSpec defines the desired state of InferenceService.
+// InferenceServiceSpec 定义 InferenceService 的期望状态。
 type InferenceServiceSpec struct {
-    // Roles is a list of logical components in the inference topology.
-    // Each role is identified by a user-defined Name and classified by ComponentType.
+    // Roles 是推理拓扑中的逻辑组件列表。
+    // 每个角色都由用户定义的 Name 标识，并按 ComponentType 分类。
     Roles []Role `json:"roles"`
     
-    // SchedulingStrategy applies cluster-wide scheduling policies (e.g., Volcano).
+    // SchedulingStrategy 应用集群范围的调度策略（例如 Volcano）。
     // +optional
     SchedulingStrategy *SchedulingStrategy `json:"schedulingStrategy,omitempty"`
 }
 
-// SchedulingStrategy defines pod-level scheduling behavior.
+// SchedulingStrategy 定义 Pod 级别的调度行为。
 type SchedulingStrategy struct {
-    // SchedulerName specifies the Kubernetes scheduler to use (e.g., "volcano").
+    // SchedulerName 指定要使用的 Kubernetes 调度器（例如 "volcano"）。
     // +optional
     SchedulerName string `json:"schedulerName,omitempty"`
 }
 
-// Role describes a logical component in the inference pipeline.
+// Role 描述推理流水线中的逻辑组件。
 type Role struct {
-    // Name is a user-defined, unique identifier for this component (e.g., "inference").
+    // Name 是该组件由用户定义的唯一标识符（例如 "inference"）。
     Name string `json:"name"`
 
-    // ComponentType indicates the semantic role. Valid values:
-    // - "worker": monolithic inference
-    // - "prefiller": prompt processing
-    // - "decoder": token generation
-    // - "router": request router with scheduling plugins
+    // ComponentType 表示语义角色。有效值：
+    // - "worker"：单体推理
+    // - "prefiller"：prompt 处理
+    // - "decoder"：token 生成
+    // - "router"：使用调度插件的请求路由器
     ComponentType ComponentType `json:"componentType"`
 
-    // Router-specific fields (only for componentType: router)
+    // Router 特有字段（仅用于 componentType: router）
     
-    // Strategy defines the routing strategy for the router component
+    // Strategy 定义 Router 组件的路由策略
     // +optional
     Strategy RoutingStrategy `json:"strategy,omitempty"`
     
-    // HTTPRoute defines the HTTPRoute spec for routing traffic (Gateway API)
+    // HTTPRoute 定义用于路由流量的 HTTPRoute 规范（Gateway API）
     // +optional
     HTTPRoute *runtime.RawExtension `json:"httproute,omitempty"`
     
-    // Gateway defines the Gateway spec for this router (Gateway API GatewaySpec)
+    // Gateway 定义该 Router 的 Gateway 规范（Gateway API GatewaySpec）
     // +optional
     Gateway *runtime.RawExtension `json:"gateway,omitempty"`
     
-    // EndpointPickerConfig is raw YAML for advanced EPP customization
+    // EndpointPickerConfig 是用于 EPP 高级定制的原始 YAML
     // +optional
     EndpointPickerConfig string `json:"endpointPickerConfig,omitempty"`
 
-    // Worker-specific fields (for prefiller/decoder/worker)
+    // Worker 特有字段（用于 prefiller/decoder/worker）
     
-    // Replicas specifies how many independent distributed instances to create.
-    // Default: 1
+    // Replicas 指定要创建多少个相互独立的分布式实例。
+    // 默认值：1
     // +optional
     Replicas *int32 `json:"replicas,omitempty"`
 
-    // Multinode enables distributed inference with a built-in Leader + Worker topology.
+    // Multinode 使用内置的 Leader + Worker 拓扑启用分布式推理。
     // +optional
     Multinode *Multinode `json:"multinode,omitempty"`
 
-    // Template defines the pod spec for this component.
-    // Uses runtime.RawExtension to avoid CRD size limits.
+    // Template 定义该组件的 Pod spec。
+    // 使用 runtime.RawExtension 避免 CRD 大小限制。
     // +optional
     Template *runtime.RawExtension `json:"template,omitempty"`
 }
 
-// Multinode enables multi-node distributed inference.
+// Multinode 启用多节点分布式推理。
 type Multinode struct {
-    // NodeCount is the number of distinct nodes to distribute this component across.
+    // NodeCount 是分布该组件所跨的不同节点数量。
     NodeCount int32 `json:"nodeCount"`
 }
 
-// InferenceServiceStatus reflects the observed state of the InferenceService.
+// InferenceServiceStatus 反映观察到的 InferenceService 状态。
 type InferenceServiceStatus struct {
-    // ObservedGeneration is the most recent generation observed by the controller.
+    // ObservedGeneration 是 Controller 最近观察到的 generation。
     // +optional
     ObservedGeneration int64 `json:"observedGeneration,omitempty"`
     
-    // Conditions represent the latest available observations of the service's state.
+    // Conditions 表示对服务状态的最新可用观察结果。
     Conditions []metav1.Condition `json:"conditions,omitempty"`
     
-    // Components summarizes the current state of each declared role/component.
-    // Key is the component's .spec.roles[].name.
+    // Components 汇总每个已声明角色/组件的当前状态。
+    // 键为组件的 .spec.roles[].name。
     // +optional
     Components map[string]ComponentStatus `json:"components,omitempty"`
 }
 
-// ComponentStatus captures the aggregated runtime state of a single inference component (role).
-// For example, with replica=2 and multinode.nodeCount=4:
-//   - DesiredReplicas: 2
-//   - NodesPerReplica: 4
-//   - TotalPods: 8 (2 * 4)
-//   - ReadyReplicas: 0/1/2 (a replica is ready only when all its nodes are ready)
-//   - ReadyPods: 0-8
+// ComponentStatus 捕获单个推理组件（角色）的聚合运行时状态。
+// 例如，replica=2 且 multinode.nodeCount=4 时：
+//   - DesiredReplicas：2
+//   - NodesPerReplica：4
+//   - TotalPods：8（2 * 4）
+//   - ReadyReplicas：0/1/2（仅当一个副本的所有节点均 Ready 时，该副本才 Ready）
+//   - ReadyPods：0-8
 type ComponentStatus struct {
-    // DesiredReplicas is the number of replicas requested (from spec.roles[].replica).
+    // DesiredReplicas 是请求的副本数（来自 spec.roles[].replica）。
     DesiredReplicas int32 `json:"desiredReplicas"`
     
-    // ReadyReplicas is the number of replicas that are fully ready.
-    // For multi-node replicas, a replica is ready only when all its nodes are ready.
+    // ReadyReplicas 是完全 Ready 的副本数。
+    // 对于多节点副本，仅当其所有节点均 Ready 时，该副本才 Ready。
     ReadyReplicas int32 `json:"readyReplicas"`
     
-    // NodesPerReplica is the number of nodes per replica (from spec.roles[].multinode.nodeCount).
-    // Defaults to 1 when multinode is not configured.
+    // NodesPerReplica 是每个副本的节点数（来自 spec.roles[].multinode.nodeCount）。
+    // 未配置 multinode 时默认为 1。
     NodesPerReplica int32 `json:"nodesPerReplica"`
     
-    // TotalPods is the total number of pods desired (= DesiredReplicas * NodesPerReplica).
+    // TotalPods 是期望的 Pod 总数（= DesiredReplicas * NodesPerReplica）。
     TotalPods int32 `json:"totalPods"`
     
-    // ReadyPods is the total number of ready pods across all replicas.
+    // ReadyPods 是所有副本中 Ready Pod 的总数。
     ReadyPods int32 `json:"readyPods"`
     
-    // Phase indicates the high-level lifecycle stage of this component.
-    // Possible values: Pending, Deploying, Running, Failed, Unknown.
+    // Phase 表示该组件的高层生命周期阶段。
+    // 可能的值：Pending、Deploying、Running、Failed、Unknown。
     Phase ComponentPhase `json:"phase"`
     
-    // LastUpdateTime is the timestamp when this component's status was last updated.
+    // LastUpdateTime 是上次更新该组件状态时的时间戳。
     // +optional
     LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty"`
 }
 
-// ComponentPhase is a simple, high-level summary of where the component is in its lifecycle.
+// ComponentPhase 是组件所处生命周期阶段的简单高层摘要。
 // +kubebuilder:validation:Enum=Pending;Deploying;Running;Failed;Unknown
 type ComponentPhase string
 

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/core-design.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/core-design.md
@@ -53,7 +53,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "Qwen/Qwen3-8B"
@@ -83,7 +83,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "Qwen/Qwen3-8B"
@@ -102,7 +102,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "Qwen/Qwen3-8B"
@@ -136,7 +136,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "deepseek-ai/DeepSeek-R1"
@@ -170,7 +170,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "deepseek-ai/DeepSeek-R1"
@@ -193,7 +193,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "deepseek-ai/DeepSeek-R1"
@@ -472,7 +472,7 @@ spec:
       spec:
         containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args: ["Qwen/Qwen3-8B"]
             ports:
               - containerPort: 8000
@@ -540,7 +540,7 @@ spec:
         schedulerName: volcano
         containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             command: ["/bin/sh", "-c"]
             args:
               - "ray start --head --port=6379 && vllm serve deepseek-ai/DeepSeek-R1 --tensor-parallel-size 32 --distributed-executor-backend ray"
@@ -562,7 +562,7 @@ spec:
         schedulerName: volcano
         containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             command: ["/bin/sh", "-c"]
             args:
               - "ray start --address=$LWS_LEADER_ADDRESS:6379 --block"
@@ -668,7 +668,7 @@ spec:
         schedulerName: volcano
         containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             # ... Prefill 配置
 ---
 # 副本 0 的 Decode LWS
@@ -696,7 +696,7 @@ spec:
         schedulerName: volcano
         containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             # ... Decode 配置
 ```
 

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/inference-deployment.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/inference-deployment.md
@@ -1,0 +1,456 @@
+---
+title: InferenceDeployment
+description: 绑定 Model 与 RuntimeProfile，并声明副本数、缓存、路由、发布与状态行为。
+---
+
+## 资源定位 {#resource-purpose}
+
+`InferenceDeployment` 是 Namespaced 资源，用于创建一个可访问的模型推理服务。它通过显式引用绑定 Base Model、可选的多个 LoRA 和 RuntimeProfile，并声明部署副本数、模型物化时机和 Gateway API 入口。
+
+下面是一个最小的 Aggregated 结构示例。省略 `spec.cache` 时使用默认的 `lazy` 模式。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-8b-chat
+  namespace: team-a
+spec:
+  modelRef:
+    kind: Model
+    name: qwen3-8b-r1
+  runtimeRef:
+    kind: RuntimeProfile
+    name: vllm-aggregated
+  replicas:
+    aggregated: 1
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+```
+
+## Spec {#spec}
+
+### API 结构 {#api-structure}
+
+```go
+type InferenceDeploymentSpec struct {
+    ModelRef   ResourceReference `json:"modelRef"`
+    RuntimeRef ResourceReference `json:"runtimeRef"`
+
+    // +listType=map
+    // +listMapKey=servedName
+    LoRA []LoRABinding `json:"lora,omitempty"`
+
+    // +kubebuilder:default={mode: lazy}
+    // +optional
+    Cache      *CachePolicy      `json:"cache,omitempty"`
+    Replicas   ReplicaSpec       `json:"replicas"`
+    Endpoint   EndpointSpec      `json:"endpoint"`
+}
+
+type LoRABinding struct {
+    ModelRef ResourceReference `json:"modelRef"`
+
+    // +kubebuilder:validation:MinLength=1
+    ServedName string `json:"servedName"`
+}
+
+type ResourceReference struct {
+    Kind string `json:"kind"`
+    Name string `json:"name"`
+}
+
+type CacheMode string
+
+const (
+    CacheModeLazy  CacheMode = "lazy"
+    CacheModeEager CacheMode = "eager"
+)
+
+type CachePolicy struct {
+    Mode CacheMode `json:"mode"`
+}
+
+type ReplicaSpec struct {
+    Aggregated *int32 `json:"aggregated,omitempty"`
+    Prefiller  *int32 `json:"prefiller,omitempty"`
+    Decoder    *int32 `json:"decoder,omitempty"`
+}
+
+type EndpointSpec struct {
+    GatewayRef     GatewayReference     `json:"gatewayRef"`
+    Hostnames      []gatewayv1.Hostname `json:"hostnames,omitempty"`
+    EndpointPicker *EndpointPickerSpec  `json:"endpointPicker,omitempty"`
+}
+
+type EndpointPickerSpec struct {
+    // 复用现有的 v1alpha1 RoutingStrategy 类型。
+    // +kubebuilder:validation:Enum=prefix-cache;kv-cache-utilization;queue-size
+    Strategy RoutingStrategy `json:"strategy"`
+}
+
+type GatewayReference struct {
+    Name        gatewayv1.ObjectName   `json:"name"`
+    Namespace   *gatewayv1.Namespace   `json:"namespace,omitempty"`
+    SectionName *gatewayv1.SectionName `json:"sectionName,omitempty"`
+}
+```
+
+### 资源引用 {#resource-references}
+
+`modelRef` 和 `runtimeRef` 使用显式的 `kind + name`：
+
+- `modelRef.kind` 只允许 `Model` 或 `ClusterModel`。
+- `runtimeRef.kind` 只允许 `RuntimeProfile` 或 `ClusterRuntimeProfile`。
+- API Group 固定为 `fusioninfer.io`，因此引用中不重复声明 `apiGroup`。
+- 引用不提供默认 Kind、selector、Namespace fallback 或同名资源回退。
+
+`modelRef` 必须指向 Base Model。LoRA 通过独立的 `spec.lora` 列表绑定，不能把 LoRA Model 直接作为 `modelRef`。
+
+### LoRA 绑定 {#lora-bindings}
+
+`spec.lora` 可以把多个 LoRA Model 绑定到同一个 Base Model 部署：
+
+```yaml
+lora:
+  - modelRef:
+      kind: Model
+      name: qwen3-8b-finance-lora-r1
+    servedName: finance
+  - modelRef:
+      kind: Model
+      name: qwen3-8b-support-lora-r1
+    servedName: customer-support
+```
+
+每个绑定包含两项信息：
+
+- `modelRef` 必须解析到具有 `spec.lora.baseModelRef` 的 LoRA Model。
+- `servedName` 是 OpenAI-compatible 请求中选择该 LoRA 时使用的模型名称。
+
+Controller 解析 LoRA 后必须确认其 `baseModelRef` 与 Deployment 的 `modelRef` 指向相同 Kind、名称和 UID。相同 `servedName` 和重复 `modelRef` 都会被拒绝。绑定数量不能超过 RuntimeProfile 的 `lora.maxLoadedAdapters`。
+
+引用的 RuntimeProfile 必须声明 `spec.lora`：
+
+- `loadingMode: preload`：Controller 在创建 workload revision 前物化全部 LoRA，并把绑定清单交给 backend 的启动集成。增加、删除或替换绑定会创建新的 workload revision。
+- `loadingMode: dynamic`：Controller 在现有 Base Model 工作负载上调和加载和卸载，不重启工作负载。增加、删除或替换绑定只更新 LoRA binding revision。
+
+P/D 模式下，同一个绑定必须加载到全部 Prefiller 和 Decoder 逻辑副本。Controller 通过 backend integration 调用各逻辑副本的 Pod-local LoRA management endpoint；backend 可以由 Leader 协调组内加载，也可以由 integration 向全部成员 fan-out。只有该副本的 Leader 和 Worker 都确认目标 digest 已加载后才计为 Ready。
+
+动态加载期间，Endpoint Picker 只发布已经在全部要求角色上 Ready 的 `servedName`。删除绑定时先停止发布并等待在途请求排空，再卸载 LoRA。使用同一个 `servedName` 替换 LoRA 制品时，如果 backend 不支持原子替换，该 LoRA 名称可能短暂不可用；Base Model 和其他 LoRA 不受影响。
+
+### 副本 {#replicas}
+
+`replicas` 使用与 RuntimeProfile 相同的字段组合：
+
+- 只设置 `aggregated` 表示 Aggregated 部署。
+- 同时设置 `prefiller` 和 `decoder` 表示 Prefill/Decode 分离部署。
+- 每个值表示对应角色的逻辑副本数，而不是 Pod 数量。
+- RuntimeProfile 为角色配置 `multinode.nodeCount` 时，一个逻辑副本会展开为一个 Leader Pod 和 `nodeCount - 1` 个 Worker Pod。
+
+修改 `replicas` 只会增加或减少可独立路由的逻辑副本，不会改变 RuntimeProfile 固定的 `multinode.nodeCount`、每个 Pod 的加速器资源或 TP/PP/DP。`replicas` 也不等于 backend 的 data parallel size：前者创建独立的工作负载组和服务 Endpoint，后者是单个逻辑副本内部的引擎并行参数。
+
+Deployment 的角色组合必须与引用的 RuntimeProfile 完全一致。引用 Aggregated Profile 时只能设置 `replicas.aggregated`；引用 P/D Profile 时必须同时设置 `replicas.prefiller` 和 `replicas.decoder`。
+
+### 缓存 {#cache}
+
+`spec.cache` 省略时默认为 `lazy`。显式设置 `cache.mode` 可以选择部署使用模型制品的时机：
+
+- `lazy`：Pod 调度到节点后，由注入的 init container 检查节点缓存。缓存缺失时下载并校验模型，完成后才启动推理引擎。
+- `eager`：创建新推理工作负载前，先在满足角色调度约束的节点上运行预热 Job。所需副本全部物化后才创建新工作负载。
+
+该策略同时应用于 Base Model 和 `spec.lora` 引用的制品。`preload` 模式要求 Base Model 与全部 LoRA 在引擎启动前可读。`dynamic` 模式新增 LoRA 时，`eager` 先在全部目标节点预热，`lazy` 则由目标节点上的受信任 materializer 按需物化；无论哪种缓存模式，物化完成后才调用 backend 加载接口。
+
+`eager` 为每个角色按“逻辑副本数 × 有效节点数”计算预热需求。有效节点数来自该角色的 `multinode.nodeCount`，未设置时为 1；Controller 在满足 Pod 模板调度约束的 distinct nodes 上各准备一份模型缓存。
+
+两种模式使用相同的内容寻址节点缓存，并以规范化 source URI、revision 或 OCI descriptor digest，以及可选 `source.digest` 派生不可变 cache key。
+
+`eager` 预热 Job 不申请或预留 GPU。模型已预热但 GPU 不可用时，工作负载可以保持 Pending；新版本失败不会提前删除仍在服务的上一版本。
+
+`pvc://` 来源也必须先复制到不可变节点缓存。引擎只读挂载缓存副本，不直接使用可变的源 PVC 内容。
+
+### Endpoint {#endpoint}
+
+`endpoint` 在 v1 中必填。Controller 根据该字段创建 Endpoint Picker、InferencePool 和 HTTPRoute：
+
+- `gatewayRef.name` 指定 HTTPRoute 连接的 Gateway。
+- `gatewayRef.namespace` 省略时使用 `InferenceDeployment` 所在 Namespace。
+- `gatewayRef.sectionName` 可选，用于选择 Gateway listener。
+- `hostnames` 写入 HTTPRoute 的同名字段，只参与入口请求匹配。
+
+`gatewayRef` 的 API Group 固定为 `gateway.networking.k8s.io`，Kind 固定为 `Gateway`，因此只需要填写名称和可选的 Namespace、SectionName。
+
+`endpointPicker` 只用于 Aggregated 部署：
+
+- 支持 `prefix-cache`、`kv-cache-utilization` 和 `queue-size`。
+- 省略时使用 Operator 配置的默认策略。
+- P/D 部署必须省略该字段；Controller 根据 `prefiller + decoder` 自动生成 Prefill 和 Decode 调度配置。
+
+Endpoint Picker 的镜像、副本数和端口由 Operator 配置管理，不属于 RuntimeProfile 或 InferenceDeployment 的用户接口。
+
+### 作用域与引用 {#scope-and-references}
+
+`InferenceDeployment` 只存在 Namespaced 形式：
+
+- 引用 `Model` 或 `RuntimeProfile` 时，只在 Deployment 所在 Namespace 查找。
+- 引用 `ClusterModel` 或 `ClusterRuntimeProfile` 时，只查找 Cluster-scoped 对象。
+- Namespaced 引用不能指定或访问其他 Namespace。
+- ClusterModel 的凭据和 ClusterRuntimeProfile 中的 Namespaced 依赖都在 Deployment 所在 Namespace 解析。
+
+跨 Namespace Gateway 是否接受生成的 HTTPRoute，由 Gateway listener 的 `allowedRoutes` 决定。FusionInfer 不修改 Gateway，也不会在引用失败后尝试其他同名对象。
+
+引用解析成功后，Status 记录目标对象的 Kind、名称、UID 和 generation。Base Model 与 Runtime 位于 `resolvedRefs`，LoRA 位于对应的 `status.lora[]` 条目。删除并以相同名称重建对象会产生新的 UID，并被视为引用目标变化。
+
+### 默认值与校验 {#defaults-and-validation}
+
+- `modelRef`、`runtimeRef`、`replicas` 和 `endpoint` 必填。
+- `modelRef.kind`、`modelRef.name`、`runtimeRef.kind` 和 `runtimeRef.name` 必填。
+- `lora` 省略时不绑定 LoRA；存在时至少包含一个条目。
+- 每个 `lora[].modelRef` 和 `servedName` 必填，`servedName` 在列表中必须唯一。
+- `lora[].modelRef` 不能重复。
+- `replicas` 只能设置 `aggregated`，或者同时设置 `prefiller` 和 `decoder`。
+- 每个副本数必须大于等于 1。
+- `cache` 省略时默认为 `{mode: lazy}`；显式设置时，`cache.mode` 只允许 `lazy` 或 `eager`。
+- `endpoint.gatewayRef.name` 必填。
+- `endpoint.endpointPicker.strategy` 只允许用于 Aggregated 部署，且必须属于支持的策略集合。
+- RuntimeProfile 角色与 Deployment 副本组合的一致性在引用解析后校验。
+- 声明 `lora` 时，RuntimeProfile 必须支持 LoRA，绑定数量不能超过 `maxLoadedAdapters`。
+- Controller 必须确认每个绑定引用 LoRA Model，并且其 `baseModelRef` 与 Deployment 的 Base Model 引用解析到相同 UID。
+- RuntimeProfile 的 backend adapter 必须支持模板中的镜像和入口参数，并且不能与模板声明的分布式编排参数冲突；不支持时 Controller 不创建新工作负载，并设置 `ReferencesResolved=False`。
+- `InferenceDeployment.spec` 可以更新；Model、Runtime、缓存模式或 Endpoint Picker 策略变化会产生新的待提升 revision。LoRA 变化是否重建 workload 由 RuntimeProfile 的 `loadingMode` 决定。
+
+不需要读取其他对象的约束由 CRD OpenAPI、CEL 或 Admission 校验。引用是否存在、角色是否一致、Secret/PVC 是否可用以及 Gateway 是否接受 Route，由 Controller 调和并通过 Conditions 报告，因此资源可以按任意顺序创建。
+
+## Status {#status}
+
+`InferenceDeployment.status` 汇总引用解析、模型物化、工作负载、路由和 rollout 状态：
+
+```go
+type InferenceDeploymentStatus struct {
+    ObservedGeneration int64                               `json:"observedGeneration,omitempty"`
+    ResolvedRefs       *ResolvedReferences                 `json:"resolvedRefs,omitempty"`
+    ModelCache         *ModelCacheStatus                   `json:"modelCache,omitempty"`
+
+    // +listType=map
+    // +listMapKey=servedName
+    LoRA               []LoRABindingStatus                 `json:"lora,omitempty"`
+
+    Components         map[string]InferenceComponentStatus `json:"components,omitempty"`
+    Endpoint           *EndpointStatus                     `json:"endpoint,omitempty"`
+    ActiveRevision     *DeploymentRevisionStatus           `json:"activeRevision,omitempty"`
+    PendingRevision    *DeploymentRevisionStatus           `json:"pendingRevision,omitempty"`
+
+    // +listType=map
+    // +listMapKey=type
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+type ResolvedReferenceStatus struct {
+    Kind       string    `json:"kind"`
+    Name       string    `json:"name"`
+    UID        types.UID `json:"uid"`
+    Generation int64     `json:"generation"`
+    Digest     string    `json:"digest,omitempty"`
+}
+
+type ModelCacheStatus struct {
+    Mode          CacheMode `json:"mode"`
+    Digest        string    `json:"digest,omitempty"`
+    DesiredCopies int32     `json:"desiredCopies,omitempty"`
+    ReadyCopies   int32     `json:"readyCopies,omitempty"`
+}
+
+type InferenceComponentStatus struct {
+    DesiredReplicas int32 `json:"desiredReplicas"`
+    ReadyReplicas   int32 `json:"readyReplicas"`
+    NodesPerReplica int32 `json:"nodesPerReplica"`
+    ReadyPods       int32 `json:"readyPods"`
+}
+
+type LoRABindingStatus struct {
+    ServedName string                              `json:"servedName"`
+    Model      *ResolvedReferenceStatus            `json:"model,omitempty"`
+    Cache      *ModelCacheStatus                   `json:"cache,omitempty"`
+    Components map[string]LoRAComponentStatus      `json:"components,omitempty"`
+
+    // +listType=map
+    // +listMapKey=type
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+type LoRAComponentStatus struct {
+    DesiredReplicas int32 `json:"desiredReplicas"`
+    ReadyReplicas   int32 `json:"readyReplicas"`
+}
+```
+
+`components` 使用稳定的 `endpointPicker`、`aggregated`、`prefiller` 和 `decoder` 键。`nodesPerReplica` 记录 RuntimeProfile 中生效的 `multinode.nodeCount`，未设置时为 1；`readyReplicas` 只统计该逻辑副本全部 `nodesPerReplica` 个 Pod 都 Ready 的副本。`ModelCacheStatus.desiredCopies` 和 `readyCopies` 分别记录当前 revision 期望和已经完成的 distinct node 缓存副本数。`activeRevision` 表示当前接收流量的版本；`pendingRevision` 表示正在物化、调度或等待提升的新版本。
+
+`status.lora` 以 `servedName` 为列表键，并为每个绑定汇总解析后的 Model、缓存副本以及各角色的加载进度。它不公开 backend management endpoint 的地址或逐 Pod 错误正文。`preload` 模式的 Ready 状态随 workload revision 提升；`dynamic` 模式直接反映当前 active revision 中的加载状态。
+
+Conditions 使用标准 `metav1.Condition`，不增加单一 `phase`：
+
+- `ReferencesResolved`：Base Model、全部 LoRA Model 和 RuntimeProfile 引用已经解析并通过消费方校验。
+- `ModelMaterialized`：当前 revision 所需的 Base Model 缓存副本已经满足；LoRA 物化状态记录在各绑定中。
+- `LoRAReady`：所有声明的 LoRA 已完成解析、物化，并加载到全部要求的逻辑副本；没有 LoRA 时为 `True`。
+- `WorkloadsReady`：所有角色的期望逻辑副本已经 Ready；多节点逻辑副本要求 Leader 和全部 Worker Pod 都 Ready。
+- `RouteReady`：Service、InferencePool、Endpoint Picker 和 HTTPRoute 已经就绪。
+- `Available`：当前 active revision 可以接受请求。
+- `Progressing`：预热、创建、扩缩容或更新仍在进行。
+- `Degraded`：调和失败并需要用户或平台管理员介入。
+
+动态模式下，单个 LoRA 失败会使 `LoRAReady=False`，但只要 active Base Model 仍可服务，`Available` 可以保持 `True`。失败的 served name 不会发布到 Endpoint Picker。
+
+每个 Condition 必须填写 `observedGeneration`、稳定的 `reason` 和可操作的 `message`。下面展示一个已经就绪的 Aggregated 部署状态：
+
+```yaml
+status:
+  observedGeneration: 2
+  resolvedRefs:
+    model:
+      kind: ClusterModel
+      name: qwen3-8b-r1
+      uid: 8bb42ec6-95a5-4dc8-904f-6a69ee9bb8c8
+      generation: 1
+      digest: sha256:7f3c9a1e4b2d8f605a7c3e9d1b4f2860c5a8e2d7f1b3096c4e8a5d2f7b1c903e
+    runtime:
+      kind: ClusterRuntimeProfile
+      name: vllm-aggregated-h100-r1
+      uid: f42e664a-bf65-4690-8e0a-93568e854e3d
+      generation: 1
+  modelCache:
+    mode: eager
+    digest: sha256:7f3c9a1e4b2d8f605a7c3e9d1b4f2860c5a8e2d7f1b3096c4e8a5d2f7b1c903e
+    desiredCopies: 2
+    readyCopies: 2
+  components:
+    aggregated:
+      desiredReplicas: 2
+      readyReplicas: 2
+      nodesPerReplica: 1
+      readyPods: 2
+    endpointPicker:
+      desiredReplicas: 1
+      readyReplicas: 1
+      nodesPerReplica: 1
+      readyPods: 1
+  endpoint:
+    routeRef:
+      name: qwen3-8b-chat
+      namespace: team-a
+    addresses:
+      - hostname: qwen3-8b.example.com
+        url: https://qwen3-8b.example.com
+  conditions:
+    - type: Available
+      status: "True"
+      observedGeneration: 2
+      reason: Ready
+      message: 当前 active revision 已就绪，可以接收请求。
+```
+
+## 示例 {#examples}
+
+### Namespaced Aggregated：默认 lazy 缓存 {#namespaced-aggregated-default-lazy-cache}
+
+Model 和 RuntimeProfile 都从 `team-a` Namespace 解析。该部署省略 `spec.cache` 以使用默认的 `lazy` 模式，创建两个 Aggregated 逻辑副本，并使用 prefix-cache Endpoint Picker。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: llama-3-8b-chat
+  namespace: team-a
+spec:
+  modelRef:
+    kind: Model
+    name: llama-3-8b-r1
+  runtimeRef:
+    kind: RuntimeProfile
+    name: vllm-aggregated-a10-r1
+  replicas:
+    aggregated: 2
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+      sectionName: https
+    hostnames:
+      - llama-3-8b.example.com
+    endpointPicker:
+      strategy: prefix-cache
+```
+
+### Cluster Prefill/Decode：eager 缓存 {#cluster-prefilldecode-eager-cache}
+
+Model 和 RuntimeProfile 使用 Cluster-scoped 对象。Controller 在启动两个 Prefiller 和四个 Decoder 逻辑副本前预热模型；P/D 部署不声明 `endpointPicker`。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-32b-chat
+  namespace: team-b
+spec:
+  modelRef:
+    kind: ClusterModel
+    name: qwen3-32b-r1
+  runtimeRef:
+    kind: ClusterRuntimeProfile
+    name: vllm-pd-h100-r1
+  cache:
+    mode: eager
+  replicas:
+    prefiller: 2
+    decoder: 4
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+      sectionName: https
+    hostnames:
+      - qwen3-32b.example.com
+```
+
+### Namespaced Aggregated：多个动态 LoRA {#namespaced-aggregated-multiple-dynamic-loras}
+
+该部署使用支持动态 LoRA 的 RuntimeProfile。两个 LoRA 分别以 `finance` 和 `customer-support` 作为请求中的模型名称。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-8b-chat
+  namespace: team-a
+spec:
+  modelRef:
+    kind: Model
+    name: qwen3-8b-r1
+  runtimeRef:
+    kind: RuntimeProfile
+    name: vllm-aggregated-lora-dynamic-r1
+  lora:
+    - modelRef:
+        kind: Model
+        name: qwen3-8b-finance-lora-r1
+      servedName: finance
+    - modelRef:
+        kind: Model
+        name: qwen3-8b-support-lora-r1
+      servedName: customer-support
+  cache:
+    mode: eager
+  replicas:
+    aggregated: 2
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+      sectionName: https
+    hostnames:
+      - qwen3-8b.example.com
+    endpointPicker:
+      strategy: prefix-cache
+```

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/model-serving.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/model-serving.md
@@ -102,7 +102,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH) # 控制器注入节点缓存中的模型路径
             ports:

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/model-serving.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/model-serving.md
@@ -1,0 +1,192 @@
+---
+title: 架构
+---
+
+FusionInfer 将模型推理拆分为三个职责独立的概念资源：
+
+- [`Model` / `ClusterModel`](./model.md) 声明模型制品的来源和不可变版本。
+- [`RuntimeProfile` / `ClusterRuntimeProfile`](./runtime-profile.md) 定义每个副本如何运行。
+- [`InferenceDeployment`](./inference-deployment.md) 绑定模型与 RuntimeProfile，并声明副本数、缓存策略和访问入口。
+
+FusionInfer 根据这三个资源创建并持续管理模型推理服务，包括下载和缓存模型、编排推理工作负载、配置流量路由，并向用户提供推理端点。同一个 Model 或 RuntimeProfile 可以被多个 InferenceDeployment 复用；每个 InferenceDeployment 独立声明副本数、缓存模式和流量入口。
+
+以下以单节点 Prefill/Decode 分离为例，展示三个核心资源如何生成 Pod 工作负载，以及请求如何通过 Gateway 和 EPP 进入推理服务。
+
+```mermaid
+flowchart LR
+    subgraph Resources["FusionInfer 核心资源"]
+        direction TB
+        Model["Model / ClusterModel<br/>声明模型来源与版本"]
+        Runtime["RuntimeProfile / ClusterRuntimeProfile<br/>声明 P/D 拓扑、镜像和 Pod 模板"]
+        Deployment["InferenceDeployment<br/>关联 Model 与 RuntimeProfile<br/>声明 replicas 与 endpoint"]
+
+        Deployment -->|"modelRef 关联"| Model
+        Deployment -->|"runtimeRef 关联"| Runtime
+    end
+
+    Controller["InferenceDeployment 控制器"]
+    Model -->|"模型来源与版本"| Controller
+    Runtime -->|"P/D 拓扑与 Pod 模板"| Controller
+    Deployment -->|"副本数与流量入口"| Controller
+
+    Client["客户端"]
+
+    subgraph Serving["单节点 P/D 推理服务"]
+        direction TB
+
+        subgraph Routing["请求入口与路由"]
+            direction LR
+            Gateway["Gateway"] --> Route["HTTPRoute"]
+            Route --> Pool["InferencePool"]
+            Pool --> EPP["EPP"]
+        end
+
+        subgraph Pods["P/D 单节点工作负载"]
+            direction LR
+            Disaggregated["DisaggregatedSet"]
+            Prefill["Prefill Pod（一个或多个）"]
+            Decode["Decode Pod（一个或多个）"]
+
+            Disaggregated --> Prefill
+            Disaggregated --> Decode
+            Prefill -->|"KV 缓存"| Decode
+        end
+
+        EPP --> Prefill
+        EPP --> Decode
+    end
+
+    Client --> Gateway
+    Controller -.->|"创建 P/D 工作负载"| Disaggregated
+    Controller -.->|"下载并挂载 Model"| Prefill
+    Controller -.->|"下载并挂载 Model"| Decode
+    Controller -.->|"创建"| Route
+    Controller -.->|"创建"| Pool
+    Controller -.->|"部署"| EPP
+```
+
+## 核心资源 {#core-resources}
+
+### Model {#model}
+
+`Model` / `ClusterModel` 声明可复用、不可变的模型制品。下面示例声明一个位于 `team-a` Namespace 的 Hugging Face 模型，并使用完整 commit SHA 固定版本。
+
+```yaml {8}
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-r1
+  namespace: team-a
+spec:
+  source:
+    uri: hf://Qwen/Qwen3-8B # 模型制品来源
+    revision: 0123456789abcdef0123456789abcdef01234567
+```
+
+详细设计见 [Model 与 ClusterModel](./model.md)。
+
+### RuntimeProfile {#runtimeprofile}
+
+`RuntimeProfile` / `ClusterRuntimeProfile` 定义单个逻辑副本如何运行，包括 Aggregated、Prefill/Decode 分离和多节点运行方式。下面示例声明一个使用单张 GPU 的单节点 Aggregated vLLM 运行模板。
+
+```yaml {15,28}
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated-r1
+  namespace: team-a
+spec:
+  backend: vllm
+  aggregated:
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH) # 控制器注入节点缓存中的模型路径
+            ports:
+              - name: http
+                containerPort: 8000
+            readinessProbe:
+              httpGet:
+                path: /health
+                port: http
+            resources:
+              requests:
+                cpu: "4"
+                memory: 16Gi
+              limits:
+                nvidia.com/gpu: "1" # 每个逻辑副本使用一张 GPU
+```
+
+详细设计见 [RuntimeProfile 与 ClusterRuntimeProfile](./runtime-profile.md)。
+
+### InferenceDeployment {#inferencedeployment}
+
+`InferenceDeployment` 绑定 Model 与 RuntimeProfile，是控制器创建模型服务实例的入口。下面示例引用前两个 Namespaced 对象，创建两个 Aggregated 逻辑副本，并通过同 Namespace 的 Gateway 发布 OpenAI 兼容端点。
+
+```yaml {7,10,14-15}
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-8b-chat
+  namespace: team-a
+spec:
+  modelRef: # 关联 Model
+    kind: Model
+    name: qwen3-8b-r1
+  runtimeRef: # 关联 RuntimeProfile
+    kind: RuntimeProfile
+    name: vllm-aggregated-r1
+  replicas:
+    aggregated: 2 # 声明两个逻辑副本
+  endpoint: # 声明推理服务入口
+    gatewayRef:
+      name: inference-gateway
+    hostnames:
+      - qwen3-8b.example.com
+    endpointPicker:
+      strategy: prefix-cache
+```
+
+详细设计见 [InferenceDeployment](./inference-deployment.md)。
+
+## 路由 {#routing}
+
+推理服务部署后，需要将推理端点暴露给用户或智能体。FusionInfer 集成 [Gateway API Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/)，根据 `InferenceDeployment.spec.endpoint` 生成 HTTPRoute、InferencePool 和 EPP，并将 HTTPRoute 关联到已有 Gateway。EPP 根据配置的策略将请求路由到可用的推理 Pod。
+
+详细设计见 [InferenceDeployment 端点](./inference-deployment.md#endpoint)。
+
+## 调和流程 {#reconciliation-flow}
+
+控制器按以下阶段调和 `InferenceDeployment`：
+
+- **解析资源**：读取 `modelRef` 和 `runtimeRef` 指向的 Model 与 RuntimeProfile。
+- **准备模型**：根据缓存策略下载模型，并确保模型缓存可用。
+- **编排工作负载**：创建或更新 LeaderWorkerSet / DisaggregatedSet，并等待工作负载就绪。
+- **配置路由**：创建或更新 HTTPRoute、InferencePool 和 EPP。
+- **更新状态**：将调和结果写入 `InferenceDeployment.status`。
+
+```mermaid
+sequenceDiagram
+    actor User as 用户
+    participant API as Kubernetes API
+    participant Controller as InferenceDeployment 控制器
+    participant Resources as Model / RuntimeProfile
+    participant Cache as 模型缓存
+    participant Workload as LeaderWorkerSet / DisaggregatedSet
+    participant Routing as HTTPRoute / InferencePool / EPP
+
+    User->>API: 创建或更新 InferenceDeployment
+    API-->>Controller: generation 变化
+    Controller->>Resources: 解析 modelRef 和 runtimeRef
+    Resources-->>Controller: 返回模型与运行配置
+    Controller->>Cache: 按 lazy 或 eager 模式下载并缓存模型
+    Cache-->>Controller: 模型缓存就绪
+    Controller->>Workload: 创建或更新推理工作负载
+    Workload-->>Controller: 工作负载就绪
+    Controller->>Routing: 创建或更新路由资源
+    Routing-->>Controller: 路由就绪
+    Controller->>API: 更新 InferenceDeployment 状态
+```

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/model.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/model.md
@@ -1,0 +1,219 @@
+---
+title: Model 与 ClusterModel
+description: 定义命名空间级或集群级的不可变模型制品，以及可选的 LoRA 适配器绑定。
+---
+
+## 资源定位 {#resource-scope}
+
+`Model` 和 `ClusterModel` 声明模型制品的来源及其版本标识：
+
+- `Model` 是 Namespaced 资源，用于 Namespace 内的模型。
+- `ClusterModel` 是 Cluster-scoped 资源，用于跨 Namespace 共享的模型。
+
+两个 Kind 使用相同的 `ModelSpec`。只有 `spec.source` 表示 Base Model；同时设置 `spec.source` 和 `spec.lora.baseModelRef` 表示 LoRA 制品。
+
+下面是一个最小的 Namespaced Base Model：
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-r1
+  namespace: team-a
+spec:
+  source:
+    uri: hf://Qwen/Qwen3-8B
+    revision: 0123456789abcdef0123456789abcdef01234567
+```
+
+## Spec {#spec}
+
+### API 结构 {#api-structure}
+
+`Model` 与 `ClusterModel` 共享以下 Go 接口：
+
+```go
+type ModelSpec struct {
+    Source ModelSource      `json:"source"`
+    LoRA   *LoRAArtifactSpec `json:"lora,omitempty"`
+}
+
+type LoRAArtifactSpec struct {
+    BaseModelRef ModelReference `json:"baseModelRef"`
+}
+
+type ModelReference struct {
+    Kind string `json:"kind"`
+    Name string `json:"name"`
+}
+
+type ModelSource struct {
+    URI            string                        `json:"uri"`
+    Revision       string                        `json:"revision,omitempty"`
+    Digest         string                        `json:"digest,omitempty"`
+    CredentialsRef *corev1.LocalObjectReference `json:"credentialsRef,omitempty"`
+}
+```
+
+`lora` 省略时表示 Base Model，存在时表示 LoRA。`revision` 和 `digest` 是否必填由 `uri` 的 scheme 决定。
+
+### 作用域与引用 {#scope-and-references}
+
+所有引用固定属于 `fusioninfer.io` API Group，只包含 `kind` 和 `name`：
+
+- Namespaced LoRA `Model` 可以引用同一 Namespace 中的 `Model` 或集群级 `ClusterModel`。
+- Cluster-scoped LoRA `ClusterModel` 只能引用 `ClusterModel`。
+- `baseModelRef` 必须指向 Base Model，不能指向另一个 LoRA。
+
+引用不提供默认 Kind、Namespace fallback 或同名资源回退。
+
+### 模型来源 {#model-sources}
+
+`source.uri` 必填，v1 支持以下来源：
+
+- `hf://<repository>`：`revision` 必填，并使用完整 commit SHA；`digest` 可选。
+- `s3://<bucket>/<prefix>`：`digest` 必填。
+- `oci://<artifact>@sha256:<digest>`：URI 必须包含 descriptor digest；`source.digest` 可选。
+- `pvc://<claim>/<subpath>`：只允许用于 Namespaced `Model`，`digest` 必填，不允许设置 `credentialsRef`。
+
+`source.digest` 使用 `sha256:<64 个小写十六进制字符>` 格式。URI scheme 必须为小写，不允许 query、fragment 或 `.`、`..` 路径段。
+
+### 凭据契约 {#credentials-contract}
+
+`source.credentialsRef` 只包含 Secret 名称，不允许指定 Namespace。省略时使用平台配置的 workload identity 或匿名访问。
+
+- `hf://`：接受 `Opaque` Secret，要求包含 `HF_TOKEN`。
+- `s3://`：接受 `Opaque` Secret，使用 AWS SDK 标准键名，同时支持 AWS S3 和 S3-compatible 存储。
+- `oci://`：接受 `kubernetes.io/dockerconfigjson` Secret，要求包含 `.dockerconfigjson`。
+- `pvc://`：不允许设置 `credentialsRef`。
+
+- Namespaced `Model`：在该 Model 所在 Namespace 中解析 Secret。
+- `ClusterModel`：在每个消费它的 `InferenceDeployment` Namespace 中独立解析同名 Secret。不同团队可以提供各自的凭据，Cluster-scoped 对象不会跨 Namespace 读取 Secret，也不会产生一份全局认证状态。
+
+### LoRA 制品语义 {#lora-artifact-semantics}
+
+LoRA Model 使用 `source` 声明 adapter 文件，并使用 `lora.baseModelRef` 声明对应的 Base Model。`baseModelRef` 必须是显式的 `kind + name` 引用，v1 不允许 LoRA 引用另一个 LoRA。
+
+LoRA Model 通过 `InferenceDeployment.spec.lora[]` 绑定到推理服务。制品中的 `baseModelRef` 表示兼容性约束，Deployment 的 `modelRef` 表示实际运行的 Base Model；Controller 只有在两者解析到相同 Kind、名称和 UID 时才加载 LoRA。加载模式、目标逻辑副本和逐角色状态由消费它的 InferenceDeployment 与 RuntimeProfile 管理。
+
+### 默认值与校验 {#defaults-and-validation}
+
+- `spec.source` 必填。
+- `revision`、`digest` 和 `credentialsRef` 必须符合对应 URI scheme 的约束。
+- `lora` 存在时，`baseModelRef.kind` 和 `baseModelRef.name` 必填。
+- `ClusterModel` 不允许使用 `pvc://`。
+- Cluster-scoped LoRA 不能引用 Namespaced `Model`。
+- `Model.spec` 和 `ClusterModel.spec` 在 v1 中不可变。修改来源、版本、凭据或 `baseModelRef` 时需要创建新对象。
+
+## Status {#status}
+
+`Model` 和 `ClusterModel` 不提供 status subresource。Model 对象存在只表示声明有效，不表示模型已经下载或加载。
+
+## 示例 {#examples}
+
+### Model：Hugging Face Base Model {#model-hugging-face-base-model}
+
+该对象位于 `team-a`，使用完整 HF commit SHA 固定仓库版本。`huggingface-token` 在同一 Namespace 中解析。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-hf-r1
+  namespace: team-a
+spec:
+  source:
+    uri: hf://Qwen/Qwen3-8B
+    revision: 0123456789abcdef0123456789abcdef01234567
+    credentialsRef:
+      name: huggingface-token
+```
+
+### Model：PVC Base Model {#model-pvc-base-model}
+
+该对象及 `qwen3-weights` PVC 都位于 `team-a`，`digest` 用于校验 PVC 中的模型内容。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-pvc-r1
+  namespace: team-a
+spec:
+  source:
+    uri: pvc://qwen3-weights/models/qwen3-8b
+    digest: sha256:7f3c9a1e4b2d8f605a7c3e9d1b4f2860c5a8e2d7f1b3096c4e8a5d2f7b1c903e
+```
+
+### Model：S3 Base Model {#model-s3-base-model}
+
+该对象从 S3-compatible 存储读取模型文件，并使用 `digest` 校验物化后的内容。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-s3-r1
+  namespace: team-a
+spec:
+  source:
+    uri: s3://team-a-models/base/qwen3-8b-r1
+    digest: sha256:4a7d1ed414474e4033ac29ccb8653d9b8f9f45278a28a74cc2d8f7f31e4b6c90
+    credentialsRef:
+      name: s3-model-reader
+```
+
+### Model：OCI Base Model {#model-oci-base-model}
+
+OCI URI 中的 descriptor digest 固定 artifact 版本，Registry 凭据通过 `kubernetes.io/dockerconfigjson` Secret 提供。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-oci-r1
+  namespace: team-a
+spec:
+  source:
+    uri: oci://registry.example.com/models/qwen3-8b@sha256:9d2e6b4a8f1c30573a7e9c2d5b608f14e1d4a7c3096b2f855c8e1a6d4f703b29
+    credentialsRef:
+      name: model-registry-credentials
+```
+
+### Model：LoRA {#model-lora}
+
+该 LoRA 位于 `team-a`，adapter 文件来自 S3，`baseModelRef` 显式引用同一 Namespace 中的 Base Model。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-8b-finance-lora-r1
+  namespace: team-a
+spec:
+  source:
+    uri: s3://team-a-models/adapters/qwen3-8b-finance-lora-r1
+    digest: sha256:c14a8d6f2e905b378f4c1a7d3e6b2095d2f8a4c7091e5b636a3d9f2e8c1b7045
+    credentialsRef:
+      name: s3-model-reader
+  lora:
+    baseModelRef:
+      kind: Model
+      name: qwen3-8b-hf-r1
+```
+
+### ClusterModel：共享 Base Model {#clustermodel-shared-base-model}
+
+ClusterModel 的字段与 Model 相同，但没有 Namespace。该普通 Base Model 可以被多个 Namespace 中的 InferenceDeployment 显式引用。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: ClusterModel
+metadata:
+  name: qwen3-14b-shared-r1
+spec:
+  source:
+    uri: hf://Qwen/Qwen3-14B
+    revision: 89abcdef0123456789abcdef0123456789abcdef
+```
+

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/router.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/router.md
@@ -61,7 +61,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - --model=Qwen/Qwen2.5-7B-Instruct
 ```
@@ -95,7 +95,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - --model=/models/llama-70b
 ```
@@ -130,7 +130,7 @@ spec:
         spec:
           containers:
             - name: prefill
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - --model=meta-llama/Llama-3-70B-Instruct
                 - --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
@@ -141,7 +141,7 @@ spec:
         spec:
           containers:
             - name: decode
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - --model=meta-llama/Llama-3-70B-Instruct
                 - --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
@@ -235,7 +235,7 @@ spec:
         spec:
           containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
             - --model=meta-llama/Llama-3-8B-Instruct
 ```
@@ -431,7 +431,7 @@ spec:
         spec:
           containers:
           - name: vllm
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
             - --model=meta-llama/Llama-3-8B-Instruct
 ```
@@ -464,7 +464,7 @@ spec:
         spec:
           containers:
             - name: prefill
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - --model=meta-llama/Llama-3-70B-Instruct
                 - --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
@@ -475,7 +475,7 @@ spec:
         spec:
           containers:
             - name: decode
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - --model=meta-llama/Llama-3-70B-Instruct
                 - --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/router.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/router.md
@@ -1,42 +1,42 @@
 ---
 sidebar_position: 2
-title: Router Controller
+title: Router 控制器
 ---
 
-:::warning Legacy API design
-This page documents routing generated from the existing `InferenceService` v1alpha1 API. In the target [`InferenceDeployment` design](./inference-deployment.md), Gateway attachment is configured through `spec.endpoint`, Aggregated routing policy is configured through `spec.endpoint.endpointPicker`, and Prefill/Decode routing is inferred from the referenced RuntimeProfile roles.
+:::warning 旧版 API 设计
+本页记录由现有 `InferenceService` v1alpha1 API 生成的路由。在目标 [`InferenceDeployment` 设计](./inference-deployment.md)中，Gateway 关联通过 `spec.endpoint` 配置，Aggregated 路由策略通过 `spec.endpoint.endpointPicker` 配置，而 Prefill/Decode 路由则根据引用的 RuntimeProfile 角色推断。
 :::
 
-# Router Controller {#router-controller}
+# Router 控制器 {#router-controller}
 
-## Summary {#summary}
+## 概述 {#summary}
 
-The FusionInfer Router Controller enables automatic creation and management of Gateway API Inference Extension resources based on `InferenceService` CRDs. This integration transforms FusionInfer-managed inference workloads into optimized inference routing systems by leveraging the Endpoint Picker (EPP) for intelligent request routing, prefix-cache aware scheduling, and load balancing.
+FusionInfer Router 控制器支持根据 `InferenceService` CRD 自动创建和管理 Gateway API Inference Extension 资源。此集成利用 Endpoint Picker (EPP) 实现智能请求路由、prefix cache 感知调度和负载均衡，将 FusionInfer 管理的推理工作负载转换为经过优化的推理路由系统。
 
-When an `InferenceService` is created with a role having `componentType: router`, the FusionInfer Router Controller generates an `InferencePool`, an `HTTPRoute`, and the EPP ServiceAccount, RBAC, ConfigMap, Deployment, and Service resources. The generated `HTTPRoute` attaches to an existing Gateway through the configured `parentRefs`; FusionInfer does not create the Gateway itself. The EPP configuration supports prefix-cache optimization, KV-cache utilization based routing, queue-aware scheduling, LoRA adapter affinity, and disaggregated prefill/decode architectures.
+创建的 `InferenceService` 中包含 `componentType: router` 的角色时，FusionInfer Router 控制器会生成 `InferencePool`、`HTTPRoute`，以及 EPP 的 ServiceAccount、RBAC、ConfigMap、Deployment 和 Service 资源。生成的 `HTTPRoute` 通过配置的 `parentRefs` 关联到现有 Gateway；FusionInfer 不会创建 Gateway 本身。EPP 配置支持 prefix cache 优化、基于 KV cache 利用率的路由、queue size 感知调度、LoRA 适配器亲和性，以及分离式 Prefill/Decode 架构。
 
-## Motivation {#motivation}
+## 动机 {#motivation}
 
-Self-hosted LLM inference workloads on Kubernetes face significant challenges around request routing, load balancing, and resource utilization. Traditional load balancers are not aware of model-specific characteristics such as KV-cache state, prefix caching opportunities, or the distinction between prefill and decode phases. This leads to suboptimal performance, increased latency, and inefficient GPU utilization.
+Kubernetes 上的自托管 LLM 推理工作负载在请求路由、负载均衡和资源利用率方面面临重大挑战。传统负载均衡器不了解模型特有的特征，例如 KV cache 状态、prefix cache 复用机会，或 Prefill 阶段与 Decode 阶段之间的区别。这会导致性能不佳、延迟增加以及 GPU 利用率低下。
 
-The Gateway API Inference Extension provides sophisticated routing capabilities specifically designed for inference workloads, but requires manual configuration of multiple CRDs and deep understanding of the plugin ecosystem. FusionInfer simplifies this by providing a higher-level abstraction with predefined routing strategies while still allowing advanced users to customize the full `EndpointPickerConfig` when needed.
+Gateway API Inference Extension 提供了专为推理工作负载设计的高级路由能力，但需要手动配置多个 CRD，并深入了解插件生态系统。FusionInfer 提供带有预定义路由策略的更高层抽象，从而简化这一过程，同时仍允许高级用户在需要时自定义完整的 `EndpointPickerConfig`。
 
-### Goals {#goals}
+### 目标 {#goals}
 
-- **Automatic Router Resource Generation**: Create and manage `InferencePool`, `HTTPRoute`, and the EPP workload and configuration resources from an `InferenceService`
-- **Predefined Routing Strategies**: Provide simple, declarative routing strategies (`prefix-cache`, `kv-cache-utilization`, `queue-size`, `lora-affinity`, `pd-disaggregation`) for common use cases
-- **Advanced Customization**: Allow power users to provide custom `EndpointPickerConfig` for fine-grained control
+- **自动生成 Router 资源**：根据 `InferenceService` 创建和管理 `InferencePool`、`HTTPRoute`，以及 EPP 工作负载和配置资源
+- **预定义路由策略**：为常见用例提供简单的声明式路由策略（`prefix-cache`、`kv-cache-utilization`、`queue-size`、`lora-affinity`、`pd-disaggregation`）
+- **高级自定义**：允许高级用户提供自定义 `EndpointPickerConfig`，以实现精细控制
 
-### Non-Goals {#non-goals}
+### 非目标 {#non-goals}
 
-- **Workload Management**: This design focuses only on router/gateway integration; actual pod/deployment management is handled by other FusionInfer components
-- **Gateway Implementation**: This does not implement a new gateway, but integrates with existing Gateway API compliant gateways via Envoy ext-proc
+- **工作负载管理**：本设计仅关注 Router/Gateway 集成；实际的 Pod/Deployment 管理由其他 FusionInfer 组件负责
+- **Gateway 实现**：本设计不实现新的 Gateway，而是通过 Envoy ext-proc 与现有符合 Gateway API 的 Gateway 集成
 
-### User Stories {#user-stories}
+### 用户故事 {#user-stories}
 
-#### Story 1: Prefix Cache Aware Routing {#story-1-prefix-cache-aware-routing}
+#### 故事 1：prefix cache 感知路由 {#story-1-prefix-cache-aware-routing}
 
-As a platform engineer, I want to deploy a Qwen model with prefix cache aware routing so that requests sharing the longest prefixes are routed to the same server to maximize KV-cache reuse.
+作为平台工程师，我希望部署一个采用 prefix cache 感知路由的 Qwen 模型，使共享最长前缀的请求被路由到同一服务器，从而最大限度地复用 KV cache。
 
 ```yaml
 apiVersion: fusioninfer.io/v1alpha1
@@ -66,11 +66,11 @@ spec:
                 - --model=Qwen/Qwen2.5-7B-Instruct
 ```
 
-This would automatically create an `InferencePool` pointing to the inference pods and configure EPP with prefix-cache aware scheduling.
+这会自动创建指向推理 Pod 的 `InferencePool`，并为 EPP 配置 prefix cache 感知调度。
 
-#### Story 2: KV-Cache Utilization Based Load Balancing {#story-2-kv-cache-utilization-based-load-balancing}
+#### 故事 2：基于 KV cache 利用率的负载均衡 {#story-2-kv-cache-utilization-based-load-balancing}
 
-As an ML engineer, I want to distribute inference requests based on available KV-cache memory to prevent OOM errors and ensure even resource utilization across all inference servers.
+作为 ML 工程师，我希望根据可用 KV cache 内存分发推理请求，以避免 OOM 错误，并确保所有推理服务器之间的资源利用率均衡。
 
 ```yaml
 apiVersion: fusioninfer.io/v1alpha1
@@ -100,11 +100,11 @@ spec:
                 - --model=/models/llama-70b
 ```
 
-This configuration routes requests to servers with the most available KV-cache memory, preventing memory exhaustion and ensuring balanced utilization.
+此配置会将请求路由到可用 KV cache 内存最多的服务器，从而避免内存耗尽，并确保利用率均衡。
 
-#### Story 3: Disaggregated Prefill/Decode Architecture {#story-3-disaggregated-prefilldecode-architecture}
+#### 故事 3：分离式 Prefill/Decode 架构 {#story-3-disaggregated-prefilldecode-architecture}
 
-As an infrastructure engineer, I want to deploy a disaggregated serving architecture where prefill (prompt processing) and decode (token generation) are handled by specialized server pools for optimal hardware utilization and latency.
+作为基础设施工程师，我希望部署一种分离式服务架构，其中 Prefill（提示词处理）和 Decode（token 生成）由专用服务器池处理，以优化硬件利用率和延迟。
 
 ```yaml
 apiVersion: fusioninfer.io/v1alpha1
@@ -147,46 +147,46 @@ spec:
                 - --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
 ```
 
-## Proposal {#proposal}
+## 提案 {#proposal}
 
-The FusionInfer Router Controller watches for `InferenceService` resources that include roles with `componentType: router`. When detected, it automatically generates and manages Gateway API Inference Extension resources to enable intelligent request routing and load balancing for LLM inference workloads.
+FusionInfer Router 控制器会监视包含 `componentType: router` 角色的 `InferenceService` 资源。检测到此类资源后，它会自动生成并管理 Gateway API Inference Extension 资源，从而为 LLM 推理工作负载提供智能请求路由和负载均衡。
 
-The router role supports two configuration approaches:
-1. **Simple strategy-based**: Use predefined routing strategies (`prefix-cache`, `kv-cache-utilization`, `queue-size`, `lora-affinity`, `pd-disaggregation`) for common use cases
-2. **Advanced custom configuration**: Provide a complete `endpointPickerConfig` for fine-grained control over scheduling plugins, profiles, and scoring algorithms
+Router 角色支持两种配置方式：
+1. **基于简单策略的配置**：为常见用例使用预定义路由策略（`prefix-cache`、`kv-cache-utilization`、`queue-size`、`lora-affinity`、`pd-disaggregation`）
+2. **高级自定义配置**：提供完整的 `endpointPickerConfig`，以精细控制调度插件、Profile 和评分算法
 
-These configurations are translated into an `InferencePool`, an `HTTPRoute`, and an EPP deployment with its supporting ServiceAccount, RBAC, Service, and ConfigMap. The resulting `HTTPRoute` references an existing Gateway, while the EPP configuration controls routing based on factors such as prefix cache hits, memory utilization, and workload characteristics.
+这些配置会转换为 `InferencePool`、`HTTPRoute`，以及包含配套 ServiceAccount、RBAC、Service 和 ConfigMap 的 EPP Deployment。生成的 `HTTPRoute` 引用现有 Gateway，而 EPP 配置则根据 prefix cache 命中、内存利用率和工作负载特征等因素控制路由。
 
-### Go Types {#go-types}
+### Go 类型 {#go-types}
 
 ```go
-// InferenceServiceSpec defines the desired state of InferenceService
+// InferenceServiceSpec 定义 InferenceService 的期望状态
 type InferenceServiceSpec struct {
-    // Roles defines the components of the inference service
+    // Roles 定义推理服务的组件
     Roles []RoleSpec `json:"roles"`
 }
 
-// Role defines a component in the inference pipeline
+// Role 定义推理流水线中的一个组件
 type RoleSpec struct {
-    // Name is the identifier for this role
+    // Name 是此角色的标识符
     Name string `json:"name"`
     
-    // ComponentType specifies the type of component
+    // ComponentType 指定组件类型
     // +kubebuilder:validation:Enum=router;prefiller;decoder;worker
     ComponentType ComponentType `json:"componentType"`
     
-    // Router-specific fields (only for componentType: router)
+    // Router 特有字段（仅用于 componentType: router）
     Strategy              RoutingStrategy        `json:"strategy,omitempty"`
     HTTPRoute             *runtime.RawExtension  `json:"httproute,omitempty"`   // Gateway API HTTPRouteSpec
-    Gateway               *runtime.RawExtension  `json:"gateway,omitempty"`     // Reserved; the controller does not reconcile Gateway resources
-    EndpointPickerConfig  string                 `json:"endpointPickerConfig,omitempty"`  // Raw YAML for advanced users
+    Gateway               *runtime.RawExtension  `json:"gateway,omitempty"`     // 预留；控制器不调和 Gateway 资源
+    EndpointPickerConfig  string                 `json:"endpointPickerConfig,omitempty"`  // 面向高级用户的原始 YAML
     
-    // Worker-specific fields (for prefiller/decoder/worker)
+    // Worker 特有字段（用于 prefiller/decoder/worker）
     Replicas       *int32                 `json:"replicas,omitempty"`
     Template       *runtime.RawExtension  `json:"template,omitempty"`  // corev1.PodTemplateSpec
 }
 
-// ComponentType defines the type of component
+// ComponentType 定义组件类型
 type ComponentType string
 
 const (
@@ -196,7 +196,7 @@ const (
     ComponentTypeWorker    ComponentType = "worker"
 )
 
-// RoutingStrategy defines the inference routing strategy
+// RoutingStrategy 定义推理路由策略
 type RoutingStrategy string
 
 const (
@@ -208,9 +208,9 @@ const (
 )
 ```
 
-### Configuration Examples {#configuration-examples}
+### 配置示例 {#configuration-examples}
 
-#### Example 1: Simple Strategy-based Configuration {#example-1-simple-strategy-based-configuration}
+#### 示例 1：基于简单策略的配置 {#example-1-simple-strategy-based-configuration}
 
 ```yaml
 apiVersion: fusioninfer.io/v1alpha1
@@ -240,10 +240,10 @@ spec:
             - --model=meta-llama/Llama-3-8B-Instruct
 ```
 
-FusionInfer automatically generates the following resources:
+FusionInfer 会自动生成以下资源：
 
 ```yaml
-# 1. HTTPRoute - Routes traffic to the InferencePool
+# 1. HTTPRoute - 将流量路由到 InferencePool
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -261,7 +261,7 @@ spec:
       name: my-service-pool
 
 ---
-# 2. InferencePool - Manages the inference backend pods
+# 2. InferencePool - 管理推理后端 Pod
 apiVersion: inference.networking.k8s.io/v1
 kind: InferencePool
 metadata:
@@ -279,7 +279,7 @@ spec:
       number: 9002
 
 ---
-# 3. EndpointPickerConfig (ConfigMap) - EPP scheduling configuration
+# 3. EndpointPickerConfig (ConfigMap) - EPP 调度配置
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -303,7 +303,7 @@ data:
         weight: 100
 
 ---
-# 4. EPP Deployment - Endpoint Picker deployment
+# 4. EPP Deployment - Endpoint Picker 部署
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -364,7 +364,7 @@ spec:
           name: my-service-epp-config
 
 ---
-# 5. EPP Service - Exposes the EPP for Envoy ext-proc
+# 5. EPP Service - 通过 Envoy ext-proc 暴露 EPP
 apiVersion: v1
 kind: Service
 metadata:
@@ -385,9 +385,9 @@ spec:
     protocol: TCP
 ```
 
-#### Example 2: Advanced Configuration with Custom EndpointPickerConfig {#example-2-advanced-configuration-with-custom-endpointpickerconfig}
+#### 示例 2：使用自定义 EndpointPickerConfig 的高级配置 {#example-2-advanced-configuration-with-custom-endpointpickerconfig}
 
-For advanced users with specific tuning requirements, FusionInfer allows direct configuration of the EndpointPickerConfig. This provides full control over scheduling behavior, plugin parameters, and scoring weights. 
+对于有特定调优需求的高级用户，FusionInfer 允许直接配置 EndpointPickerConfig。这样可以完全控制调度行为、插件参数和评分权重。
 
 ```yaml
 apiVersion: fusioninfer.io/v1alpha1
@@ -398,7 +398,7 @@ spec:
   roles:
     - name: gateway
       componentType: router
-      # Direct control over EPP configuration for advanced tuning
+      # 直接控制 EPP 配置以进行高级调优
       endpointPickerConfig: |
         apiVersion: inference.networking.x-k8s.io/v1alpha1
         kind: EndpointPickerConfig
@@ -436,9 +436,9 @@ spec:
             - --model=meta-llama/Llama-3-8B-Instruct
 ```
 
-#### Example 3: Disaggregated Prefill/Decode Architecture {#example-3-disaggregated-prefilldecode-architecture}
+#### 示例 3：分离式 Prefill/Decode 架构 {#example-3-disaggregated-prefilldecode-architecture}
 
-For large-scale LLM deployments, disaggregated prefill/decode architecture separates the compute-intensive prompt processing (prefill) phase from the memory-intensive token generation (decode) phase. This allows independent scaling and optimization of each phase:
+对于大规模 LLM 部署，分离式 Prefill/Decode 架构将计算密集型提示词处理（Prefill）阶段与内存密集型 token 生成（Decode）阶段分开。这样可以独立扩缩和优化每个阶段：
 
 ```yaml
 apiVersion: fusioninfer.io/v1alpha1
@@ -481,14 +481,14 @@ spec:
                 - --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
 ```
 
-**Generated Resources:**
+**生成的资源：**
 
-The FusionInfer Router Controller creates the following Gateway API and EPP resources for a disaggregated prefill/decode architecture. The Gateway referenced by the generated `HTTPRoute` must already exist.
+FusionInfer Router 控制器会为分离式 Prefill/Decode 架构创建以下 Gateway API 和 EPP 资源。生成的 `HTTPRoute` 所引用的 Gateway 必须已经存在。
 
-> **Note**: In a complete P/D deployment, decode pods typically include a sidecar for orchestrating communication with prefill pods. This sidecar deployment is managed by the workload component, not the gateway component.
+> **注意**：在完整的 P/D 部署中，Decode Pod 通常包含一个用于编排与 Prefill Pod 通信的 sidecar。该 sidecar 的部署由工作负载组件管理，而不是由 Gateway 组件管理。
 
 ```yaml
-# 1. InferencePool - Single pool managing both prefill and decode pods
+# 1. InferencePool - 管理 Prefill 和 Decode Pod 的单一池
 apiVersion: inference.networking.k8s.io/v1
 kind: InferencePool
 metadata:
@@ -506,7 +506,7 @@ spec:
   - number: 8000
 
 ---
-# 2. ConfigMap - P/D-aware Endpoint Picker configuration
+# 2. ConfigMap - P/D 感知的 Endpoint Picker 配置
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -553,7 +553,7 @@ data:
         weight: 50
 
 ---
-# 3. HTTPRoute - Routes traffic to the EPP
+# 3. HTTPRoute - 将流量路由到 EPP
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -575,7 +575,7 @@ spec:
       kind: InferencePool
 
 ---
-# 4. EPP Deployment and Service (automatically configured)
+# 4. EPP Deployment 和 Service（自动配置）
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -626,19 +626,19 @@ spec:
     port: 9090
 ```
 
-## Strategy to EndpointPickerConfig Mapping {#strategy-to-endpointpickerconfig-mapping}
+## 路由策略到 EndpointPickerConfig 的映射 {#strategy-to-endpointpickerconfig-mapping}
 
-FusionInfer automatically generates the appropriate EndpointPickerConfig based on the routing strategy:
+FusionInfer 会根据路由策略自动生成相应的 EndpointPickerConfig：
 
-| Routing Strategy | Generated Plugins | Use Case |
+| 路由策略 | 生成的插件 | 用例 |
 |-----------------|------------------|----------|
-| `prefix-cache` | • `prefix-cache-scorer` (with optimized parameters)<br/>• `max-score-picker`<br/>• Single `default` scheduling profile | Route requests with longest shared prefixes to same server while balancing with KV-cache utilization and queue depth |
-| `kv-cache-utilization` | • `kv-cache-utilization-scorer`<br/>• `max-score-picker`<br/>• Single `default` scheduling profile | Balance load based on memory usage across inference servers |
-| `queue-size` | • `queue-scorer`<br/>• `max-score-picker`<br/>• Single `default` scheduling profile | Minimize request waiting time by routing to least loaded servers |
-| `lora-affinity` | • `lora-affinity-scorer`<br/>• `max-score-picker`<br/>• Single `default` scheduling profile | Route requests to servers with matching LoRA adapters for multi-adapter serving |
-| `pd-disaggregation` | • `pd-profile-handler`<br/>• `prefill-header-handler`<br/>• `by-label` filters (for prefiller/decoder)<br/>• `prefix-cache-scorer`<br/>• `max-score-picker`<br/>• Two profiles: `prefill` and `decode` | Separate compute-intensive prefill from memory-intensive decode phases |
+| `prefix-cache` | • `prefix-cache-scorer`（使用优化参数）<br/>• `max-score-picker`<br/>• 单个 `default` 调度 Profile | 将具有最长共享前缀的请求路由到同一服务器，同时兼顾 KV cache 利用率和 queue size |
+| `kv-cache-utilization` | • `kv-cache-utilization-scorer`<br/>• `max-score-picker`<br/>• 单个 `default` 调度 Profile | 根据各推理服务器的内存使用情况均衡负载 |
+| `queue-size` | • `queue-scorer`<br/>• `max-score-picker`<br/>• 单个 `default` 调度 Profile | 将请求路由到负载最低的服务器，从而最大限度缩短请求等待时间 |
+| `lora-affinity` | • `lora-affinity-scorer`<br/>• `max-score-picker`<br/>• 单个 `default` 调度 Profile | 将请求路由到具有匹配 LoRA 适配器的服务器，以支持多适配器服务 |
+| `pd-disaggregation` | • `pd-profile-handler`<br/>• `prefill-header-handler`<br/>• `by-label` 过滤器（用于 prefiller/decoder）<br/>• `prefix-cache-scorer`<br/>• `max-score-picker`<br/>• 两个 Profile：`prefill` 和 `decode` | 将计算密集型 Prefill 阶段与内存密集型 Decode 阶段分离 |
 
-**prefix-cache:**
+**prefix-cache：**
 ```yaml
 plugins:
 - type: prefix-cache-scorer
@@ -655,7 +655,7 @@ schedulingProfiles:
     weight: 100
 ```
 
-**kv-cache-utilization:**
+**kv-cache-utilization：**
 ```yaml
 plugins:
 - type: kv-cache-utilization-scorer
@@ -668,7 +668,7 @@ schedulingProfiles:
     weight: 100
 ```
 
-**queue-size:**
+**queue-size：**
 ```yaml
 plugins:
 - type: queue-scorer
@@ -681,7 +681,7 @@ schedulingProfiles:
     weight: 100
 ```
 
-**lora-affinity:**
+**lora-affinity：**
 ```yaml
 plugins:
 - type: lora-affinity-scorer
@@ -694,7 +694,7 @@ schedulingProfiles:
     weight: 100
 ```
 
-**pd-disaggregation:**
+**pd-disaggregation：**
 ```yaml
 plugins:
 - type: pd-profile-handler
@@ -734,21 +734,21 @@ schedulingProfiles:
     weight: 50
 ```
 
-## Implementation Phases {#implementation-phases}
+## 实施阶段 {#implementation-phases}
 
-### Phase 1: Core Router Integration {#phase-1-core-router-integration}
+### 阶段 1：核心 Router 集成 {#phase-1-core-router-integration}
 
-The first phase focuses on establishing the fundamental router capabilities for standard inference workloads:
+第一阶段侧重于为标准推理工作负载建立基础 Router 能力：
 
-**Deliverables:**
-- Automatic generation of `InferencePool`, `HTTPRoute`, and the EPP workload and configuration resources
-- Support for basic routing strategies:
-  - `prefix-cache`: Route requests with shared prefixes to optimize cache utilization
-  - `kv-cache-utilization`: Balance load based on memory usage
-  - `queue-size`: Minimize request waiting time
-  - `lora-affinity`: Route to servers with matching LoRA adapters
-- Custom `endpointPickerConfig` support for advanced users
+**交付成果：**
+- 自动生成 `InferencePool`、`HTTPRoute`，以及 EPP 工作负载和配置资源
+- 支持基本路由策略：
+  - `prefix-cache`：将具有共享前缀的请求路由到同一服务器，以优化 prefix cache 利用率
+  - `kv-cache-utilization`：根据内存使用情况均衡负载
+  - `queue-size`：最大限度缩短请求等待时间
+  - `lora-affinity`：路由到具有匹配 LoRA 适配器的服务器
+- 为高级用户提供自定义 `endpointPickerConfig` 支持
 
-### Phase 2: Disaggregated Prefill/Decode Support {#phase-2-disaggregated-prefilldecode-support}
+### 阶段 2：分离式 Prefill/Decode 支持 {#phase-2-disaggregated-prefilldecode-support}
 
-The second phase adds support for advanced Disaggregated Prefill/Decode architectures that separate compute-intensive prefill from memory-intensive decode operations.
+第二阶段增加对高级分离式 Prefill/Decode 架构的支持，将计算密集型 Prefill 操作与内存密集型 Decode 操作分开。

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/runtime-profile.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/runtime-profile.md
@@ -25,7 +25,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
             ports:
@@ -179,7 +179,7 @@ Runtime 命令应通过 `$(FUSION_MODEL_PATH)` 读取模型，不应写死缓存
 
 声明 LoRA 绑定时，Operator 还把当前 Deployment 的 adapter projection 只读挂载到 `/adapters`，并生成 `/var/run/fusioninfer/lora/adapters.json`。Manifest 使用内部 binding key 映射 `servedName`、resolved Model UID、digest 和容器内路径；路径不直接使用用户提供的 served name。引擎容器只能看到当前 Deployment 已绑定的 LoRA，不能浏览节点缓存根目录。
 
-生产环境中的推理镜像必须使用 OCI digest 固定。以下示例使用官方版本化镜像 `vllm/vllm-openai:v0.26.0` 以保持可读性，部署时需要替换为对应版本的 digest-pinned 镜像。
+生产环境中的推理镜像必须使用 OCI digest 固定。以下示例使用官方版本化镜像 `vllm/vllm-openai:v0.27.1` 以保持可读性，部署时需要替换为对应版本的 digest-pinned 镜像。
 
 ### 作用域与引用 {#scope-and-references}
 
@@ -236,7 +236,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
             ports:
@@ -272,7 +272,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --kv-transfer-config
@@ -290,7 +290,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --kv-transfer-config
@@ -324,7 +324,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --port
@@ -367,7 +367,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --enable-lora

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/runtime-profile.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/runtime-profile.md
@@ -1,0 +1,386 @@
+---
+title: RuntimeProfile 与 ClusterRuntimeProfile
+description: 定义可复用的运行模板，用于 Aggregated、Prefill/Decode 分离和多节点推理。
+---
+
+## 资源定位 {#resource-definition}
+
+`RuntimeProfile` 和 `ClusterRuntimeProfile` 声明可复用的推理运行模板，包括 backend、推理镜像、启动参数、LoRA 加载能力、Pod 形态以及 Aggregated 或 Prefill/Decode 角色：
+
+- `RuntimeProfile` 是 Namespaced 资源，用于 Namespace 内复用。
+- `ClusterRuntimeProfile` 是 Cluster-scoped 资源，用于跨 Namespace 共享。
+
+两个 Kind 使用相同的 `RuntimeProfileSpec`。Profile 描述每个角色的单个逻辑副本，不包含部署副本数，也不绑定具体 Model。下面是一个最小的 Aggregated 结构示例：
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated
+  namespace: team-a
+spec:
+  backend: vllm
+  aggregated:
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+            ports:
+              - name: http
+                containerPort: 8000
+```
+
+## Spec {#spec}
+
+### API 结构 {#api-structure}
+
+`RuntimeProfile` 与 `ClusterRuntimeProfile` 共享以下 Go 接口：
+
+```go
+// +kubebuilder:validation:Enum=vllm;sglang;trtllm
+type RuntimeBackend string
+
+const (
+    RuntimeBackendVLLM   RuntimeBackend = "vllm"
+    RuntimeBackendSGLang RuntimeBackend = "sglang"
+    RuntimeBackendTRTLLM RuntimeBackend = "trtllm"
+)
+
+type RuntimeProfileSpec struct {
+    Backend    RuntimeBackend        `json:"backend"`
+    LoRA       *RuntimeLoRASpec       `json:"lora,omitempty"`
+    Aggregated *RuntimeComponentSpec `json:"aggregated,omitempty"`
+    Prefiller  *RuntimeComponentSpec `json:"prefiller,omitempty"`
+    Decoder    *RuntimeComponentSpec `json:"decoder,omitempty"`
+}
+
+// +kubebuilder:validation:Enum=preload;dynamic
+type LoRALoadingMode string
+
+const (
+    LoRALoadingModePreload LoRALoadingMode = "preload"
+    LoRALoadingModeDynamic LoRALoadingMode = "dynamic"
+)
+
+type RuntimeLoRASpec struct {
+    LoadingMode LoRALoadingMode `json:"loadingMode"`
+
+    // 单个 InferenceDeployment 的控制面上限。
+    // +kubebuilder:validation:Minimum=1
+    MaxLoadedAdapters int32 `json:"maxLoadedAdapters"`
+}
+
+type RuntimeComponentSpec struct {
+    // 解码并校验为 corev1.PodTemplateSpec。
+    // +kubebuilder:pruning:PreserveUnknownFields
+    PodTemplate runtime.RawExtension `json:"podTemplate"`
+
+    Multinode *MultinodeSpec `json:"multinode,omitempty"`
+}
+
+type MultinodeSpec struct {
+    // +kubebuilder:validation:Minimum=2
+    NodeCount int32 `json:"nodeCount"`
+}
+```
+
+`podTemplate` 使用 `runtime.RawExtension`，避免在 CRD 中重复展开完整 Kubernetes Pod schema。Admission 和 Controller 必须将其严格解码为当前支持的 `corev1.PodTemplateSpec`。
+
+### 角色字段 {#role-fields}
+
+合法的角色字段组合如下：
+
+- 只设置 `aggregated` 表示聚合推理。
+- 同时设置 `prefiller` 和 `decoder` 表示 Prefill/Decode 分离。
+- `aggregated` 不能与 `prefiller` 或 `decoder` 共存。
+- `prefiller` 和 `decoder` 必须同时出现。
+
+每个角色使用相同的 `RuntimeComponentSpec`：
+
+- 未设置 `multinode` 时，`podTemplate` 表示一个完整的单节点逻辑副本。
+- 设置 `multinode` 时，`nodeCount` 表示每个逻辑副本使用的总节点数，其中包含一个 Leader 和 `nodeCount - 1` 个 Worker。
+- Leader 和 Worker 都由同一份 `podTemplate` 派生，并且必须分布在不同 Kubernetes Node。
+- 单节点多 GPU 引擎不应设置 `multinode`，而应在一个 Pod 中申请多张 GPU。
+
+例如，`multinode.nodeCount: 4` 表示一个逻辑副本由 1 个 Leader Pod 和 3 个 Worker Pod 组成。如果对应的 `InferenceDeployment` 设置 `replicas.aggregated: 2`，Controller 会创建 2 个这样的逻辑副本，也就是 2 个 Leader Pod 和 6 个 Worker Pod，共 8 个 Pod。
+
+### Backend 分布式运行 {#distributed-backend-execution}
+
+`backend` 必填，支持 `vllm`、`sglang` 和 `trtllm`。它只选择引擎适配器；Aggregated 或 P/D 模式仍由角色字段组合决定。同一 RuntimeProfile 中的所有角色使用相同 backend。
+
+设置 `multinode` 后，Controller 根据 backend 和 Pod 在逻辑副本中的角色生成启动配置：
+
+- RuntimeProfile 作者只声明一次镜像、TP/PP/DP 等引擎并行参数、资源和调度约束，不再分别编写 Leader 与 Worker 模板。
+- `multinode.nodeCount`、每个 Pod 的加速器资源和引擎并行参数固定在 RuntimeProfile 中。
+- Leader 负责建立分布式运行环境并启动推理服务；Worker 只加入该逻辑副本的分布式运行环境。
+- backend adapter 可以包装或重写生成后 Pod 中 `engine` 容器的 `command` 和 `args`，但仅用于注入 multiprocessing executor、地址、rank、`nnodes` 等 Leader/Worker 编排差异。
+- adapter 不根据 `nodeCount` 推导或修改 RuntimeProfile 声明的 TP/PP/DP；这些引擎并行参数在所有逻辑副本中保持不变。
+- adapter 只处理分布式启动所需的差异；用户声明的环境变量、资源、volume、探针和调度约束继续应用于所有 Pod。
+- Controller 不根据镜像名或任意命令字符串猜测 backend。
+
+多节点 vLLM 固定使用 multiprocessing executor，`--distributed-executor-backend mp` 及组内启动参数由 backend adapter 注入。SGLang 使用原生分布式启动。Leader/Worker 命令和受管参数见 [工作负载编排：Backend 分布式运行](./workload-orchestration.md#backend-distributed-execution)。
+
+每个 backend 的受支持镜像契约、入口形式和 adapter 保留的编排参数必须随 Operator 版本记录并测试。RuntimeProfile 不能预先声明由 adapter 管理的 executor、地址、rank、`nnodes` 或 headless 参数；发生冲突或自定义入口无法处理时，Controller 在消费 RuntimeProfile 时拒绝创建新工作负载。adapter 只识别版本化契约中的有限参数，不解析任意 CLI 或 shell 脚本，也不验证模型与 TP/PP/DP 的数学兼容性；这些参数由 Profile 作者负责验证。
+
+### LoRA 加载能力 {#lora-loading-capabilities}
+
+`spec.lora` 声明该 Profile 能否消费 `InferenceDeployment.spec.lora`，并固定 LoRA 的加载生命周期：
+
+- 省略 `lora` 时，该 Profile 不接受 LoRA 绑定。
+- `loadingMode: preload` 在引擎启动前物化并挂载全部 LoRA。绑定集合变化会生成新的 workload revision。
+- `loadingMode: dynamic` 在 Base Model 工作负载运行后加载或卸载 LoRA，不因绑定集合变化重启 Base Model。
+- `maxLoadedAdapters` 限制单个 InferenceDeployment 可以同时绑定的 LoRA 数量。
+
+`maxLoadedAdapters` 是跨 backend 的控制面上限，不替代引擎自己的显存、CPU 缓存、最大 LoRA rank 或 batch 并发参数。这些 backend-specific 参数继续由 Profile 作者固定在 `podTemplate` 中；对应 backend 的 LoRA 集成会校验已知参数与控制面上限是否兼容，而不会修改 TP/PP/DP。
+
+LoRA 加载配置位于 Profile 顶层，因此 Aggregated、Prefiller 和 Decoder 使用相同模式。P/D 部署必须把每个 LoRA 加载到 Prefiller 与 Decoder 的全部可路由逻辑副本，不能为两个角色选择不同的加载模式。
+
+动态模式由 `InferenceDeployment` Controller 通过 Operator 内置的 backend integration 调用 Pod-local LoRA management endpoint。Controller 是唯一的 Reconciler，持有期望绑定、重试和状态；management endpoint 只执行幂等的 load、unload 和 list 操作。backend 已提供满足契约的管理接口时直接使用；否则 Operator 可以注入薄的无状态代理作为 backend-specific 实现细节，而不是再运行第二个控制循环。管理端口不会加入推理 Service、InferencePool 或 HTTPRoute。
+
+多节点的动态加载以逻辑副本为单位。backend integration 根据引擎能力调用 Leader 协调接口，或向该逻辑副本的全部成员执行受控 fan-out；只有 Leader 和全部 Worker 都确认目标 digest 已加载，该逻辑副本才计为 Ready。成员选择、请求格式和错误归一化隐藏在 backend integration 内，不进入 RuntimeProfile 接口。
+
+### Pod 模板 {#podtemplate}
+
+Pod 模板是完整的 `corev1.PodTemplateSpec`，但只允许一层模板：
+
+- 每个角色的 `podTemplate` 必须包含名为 `engine` 的容器。
+- `engine` 必须声明唯一的命名端口 `http`；多节点模式只把 Leader 注册为服务 Endpoint。
+- 所有 Pod 使用 Operator 配置的 Volcano scheduler；模板中的 `schedulerName` 必须为空或与该配置一致。
+- 同一份模板的 metadata、容器、资源和调度约束应用于 Leader 与 Worker，backend adapter 只生成角色相关的启动配置和保留环境变量。
+- `InferenceDeployment` 不提供第二层 Pod override。
+- 模板 `metadata` 只允许设置 labels 和 annotations；资源名称、Namespace、OwnerReference、finalizer 和其他服务端元数据由 Controller 管理。
+- 配置 `lora` 时，模板入口必须符合对应 backend 的 LoRA 契约。Profile 负责声明引擎的 LoRA enablement、rank 和 backend-specific 容量参数；Deployment 不能覆盖这些参数。
+- 动态模式所需的管理端口、volume、mount 和环境变量由 Operator 注入，模板不能占用这些保留名称。只有 backend 原生接口不能满足内部 lifecycle 契约时才注入薄的无状态代理；该代理不持有期望状态，也不执行独立调和。
+
+Operator 在所有 `engine` 容器中提供统一的模型挂载契约：
+
+```text
+volume: fusioninfer-model
+volume: fusioninfer-model-metadata
+initContainer: fusioninfer-model-init
+env: FUSION_MODEL_PATH
+env: FUSION_MODEL_METADATA_PATH
+volume: fusioninfer-lora
+env: FUSION_LORA_ROOT
+env: FUSION_LORA_MANIFEST
+```
+
+模型内容以只读方式挂载到固定路径 `/models`，并注入：
+
+```text
+FUSION_MODEL_PATH=/models
+FUSION_MODEL_METADATA_PATH=/var/run/fusioninfer/model/model.json
+```
+
+Runtime 命令应通过 `$(FUSION_MODEL_PATH)` 读取模型，不应写死缓存根目录。Profile 不能声明上述保留字段，也不能覆盖 Operator 管理的 materializer 或 Endpoint Picker 镜像。
+
+声明 LoRA 绑定时，Operator 还把当前 Deployment 的 adapter projection 只读挂载到 `/adapters`，并生成 `/var/run/fusioninfer/lora/adapters.json`。Manifest 使用内部 binding key 映射 `servedName`、resolved Model UID、digest 和容器内路径；路径不直接使用用户提供的 served name。引擎容器只能看到当前 Deployment 已绑定的 LoRA，不能浏览节点缓存根目录。
+
+生产环境中的推理镜像必须使用 OCI digest 固定。以下示例使用官方版本化镜像 `vllm/vllm-openai:v0.26.0` 以保持可读性，部署时需要替换为对应版本的 digest-pinned 镜像。
+
+### 作用域与引用 {#scope-and-references}
+
+`RuntimeProfile` 自身不包含 `modelRef`。具体 Model、运行模板和副本数由 `InferenceDeployment` 绑定。
+
+Pod 模板可以引用 ServiceAccount、Secret、ConfigMap 和 PVC：
+
+- `RuntimeProfile` 中的 Namespaced 依赖在 Profile 所在 Namespace 中解析。
+- `ClusterRuntimeProfile` 中的 Namespaced 依赖名称在消费它的 `InferenceDeployment` Namespace 中解析。
+- `ClusterRuntimeProfile` 不能固定其他 Namespace 中的依赖。
+- 创建 `ClusterRuntimeProfile` 时只校验引用结构；依赖是否存在由消费方调和并通过 `InferenceDeployment.status` 报告。
+
+Profile 不拥有或修改这些依赖。对启动行为有影响的 ConfigMap 和 Secret 应使用 immutable 对象或版本化名称。
+
+### 默认值与校验 {#defaults-and-validation}
+
+- `backend` 必填，只允许 `vllm`、`sglang` 或 `trtllm`。
+- `lora.loadingMode` 只允许 `preload` 或 `dynamic`；`maxLoadedAdapters` 必须大于等于 1。
+- 只有当前 Operator 版本为指定 backend 和模板入口实现了对应 LoRA 模式时，Profile 才能被消费。
+- 必须设置 `aggregated`，或者同时设置 `prefiller` 和 `decoder`。
+- 每个已声明角色都必须提供 `podTemplate`。
+- 设置 `multinode` 时，`nodeCount` 必须大于等于 2；省略时按单节点处理。
+- RawExtension 必须能够严格解码为 `corev1.PodTemplateSpec`。
+- 模板必须包含 `engine` 容器及唯一的 `http` 命名端口。
+- 模板不能占用 Operator 保留的 volume、init container、环境变量、挂载路径、label 或 annotation。
+- backend adapter 必须支持模板中声明的镜像和入口参数。
+- 模板不能声明 backend adapter 保留的 executor、地址、rank、`nnodes` 或 headless 参数。
+- 模板镜像必须使用 OCI digest 固定。
+- `RuntimeProfile.spec` 和 `ClusterRuntimeProfile.spec` 在 v1 中不可变。修改 backend、镜像、命令、资源、`multinode` 或 Pod 模板时需要创建新对象。
+
+## Status {#status}
+
+`RuntimeProfile` 和 `ClusterRuntimeProfile` 不提供 status subresource，也不需要独立 Controller。对象内约束由 Admission 校验，Namespace 依赖和实际运行状态由消费它的 `InferenceDeployment.status` 持有。
+
+## 示例 {#examples}
+
+### RuntimeProfile：单节点 Aggregated {#runtimeprofile-single-node-aggregated}
+
+该 Profile 描述一个使用单张 GPU 的 Aggregated 逻辑副本。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated-a10-r1
+  namespace: team-a
+spec:
+  backend: vllm
+  aggregated:
+    podTemplate:
+      metadata:
+        labels:
+          example.fusioninfer.io/runtime: vllm
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+            ports:
+              - name: http
+                containerPort: 8000
+            readinessProbe:
+              httpGet:
+                path: /health
+                port: http
+            resources:
+              requests:
+                cpu: "4"
+                memory: 16Gi
+              limits:
+                nvidia.com/gpu: "1"
+        nodeSelector:
+          accelerator: a10
+```
+
+### ClusterRuntimeProfile：Prefill/Decode 分离 {#clusterruntimeprofile-prefilldecode-disaggregation}
+
+Prefiller 和 Decoder 分别声明 KV 传输角色。Profile 不包含副本数或 Endpoint Picker 策略。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: ClusterRuntimeProfile
+metadata:
+  name: vllm-pd-h100-r1
+spec:
+  backend: vllm
+  prefiller:
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --kv-transfer-config
+              - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "2"
+        nodeSelector:
+          accelerator: h100
+  decoder:
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --kv-transfer-config
+              - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "1"
+        nodeSelector:
+          accelerator: h100
+```
+
+### RuntimeProfile：多节点 Aggregated {#runtimeprofile-multinode-aggregated}
+
+每个逻辑副本由一个 Leader Pod 和三个 Worker Pod 组成，共使用四个节点。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated-4node-r1
+  namespace: team-a
+spec:
+  backend: vllm
+  aggregated:
+    multinode:
+      nodeCount: 4
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --port
+              - "8000"
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "4"
+              - --data-parallel-size
+              - "1"
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+        nodeSelector:
+          accelerator: h100
+```
+
+`backend: vllm` adapter 根据 `nodeCount: 4` 为 Leader 和 Worker 注入 multiprocessing executor、节点数、地址和 rank。它保留 Profile 中固定的 `TP=8`、`PP=4` 和 `DP=1`，用户只维护一份 vLLM 参数和 Pod 模板。
+
+### RuntimeProfile：动态 LoRA {#runtimeprofile-dynamic-lora}
+
+该 Profile 允许一个 Deployment 动态绑定最多八个 LoRA。vLLM 的 LoRA enablement 和 backend-specific 容量仍固定在 Pod 模板中；Operator 负责配置受保护的 Pod-local management endpoint 和 runtime updating 环境变量，`InferenceDeployment` Controller 通过 backend integration 调和加载状态。
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated-lora-dynamic-r1
+  namespace: team-a
+spec:
+  backend: vllm
+  lora:
+    loadingMode: dynamic
+    maxLoadedAdapters: 8
+  aggregated:
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --enable-lora
+              - --max-loras
+              - "8"
+              - --max-cpu-loras
+              - "8"
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "1"
+        nodeSelector:
+          accelerator: h100
+```

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/workload-orchestration.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/workload-orchestration.md
@@ -1,0 +1,730 @@
+---
+title: 工作负载编排
+description: 说明 FusionInfer 如何生成并管理 Aggregated、Prefill/Decode 分离和多节点工作负载。
+---
+
+## 设计范围 {#design-scope}
+
+FusionInfer 根据 [`RuntimeProfile`](./runtime-profile.md) 定义的每副本运行配置和 [`InferenceDeployment`](./inference-deployment.md) 的副本数生成 LeaderWorkerSet（LWS）、DisaggregatedSet 与 Volcano PodGroup。
+
+## 核心概念 {#core-concepts}
+
+InferenceDeployment 使用 `replicas.<role>` 控制每个角色运行多少个副本。在多节点场景中，一个副本可以由多个 Pod 共同组成，这些 Pod 共同构成一个“逻辑副本”：
+
+- 单节点逻辑副本包含一个 Pod。
+- 多节点逻辑副本包含一个 Leader Pod 和若干 Worker Pod。
+
+RuntimeProfile 定义每个逻辑副本如何运行：
+
+- `podTemplate` 定义该副本中 Pod 的镜像、资源和引擎参数。
+- `multinode.nodeCount` 定义该副本包含多少个 Pod。
+  - 未设置 `multinode` 时，`nodeCount` 按 1 处理。
+  - 设置 `nodeCount: 4` 时，一个副本包含一个 Leader 和三个 Worker。
+
+RuntimeProfile 中的 `nodeCount: 4` 表示每个逻辑副本包含四个 Pod：
+
+```yaml {10}
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated-4node-r1
+  namespace: team-a
+spec:
+  backend: vllm
+  aggregated:
+    multinode:
+      nodeCount: 4
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "4"
+              - --data-parallel-size
+              - "1"
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+```
+
+InferenceDeployment 中的 `aggregated: 2` 表示运行两个使用上述配置的副本：
+
+```yaml {16}
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-70b
+  namespace: team-a
+spec:
+  modelRef:
+    kind: ClusterModel
+    name: qwen3-70b-r1
+  runtimeRef:
+    kind: RuntimeProfile
+    name: vllm-aggregated-4node-r1
+  cache:
+    mode: eager
+  replicas:
+    aggregated: 2
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+      sectionName: https
+    hostnames:
+      - qwen3-70b.example.com
+    endpointPicker:
+      strategy: prefix-cache
+```
+
+最终创建：
+
+```text
+逻辑副本 0：1 个 Leader + 3 个 Worker
+逻辑副本 1：1 个 Leader + 3 个 Worker
+
+总 Pod 数：2 × 4 = 8
+```
+
+## Aggregated 模式 {#aggregated-mode}
+
+Aggregated 模式生成一个 LeaderWorkerSet：
+
+- LWS `spec.replicas` 等于 `InferenceDeployment.spec.replicas.aggregated`。
+- 每个 LWS group 表示一个 Aggregated 逻辑副本。
+- `leaderWorkerTemplate.size` 等于 `nodesPerReplica(aggregated)`。
+- `workerTemplate` 始终存在；多节点时额外生成 `leaderTemplate`，两者都来自同一份 RuntimeProfile `podTemplate`。
+- LWS 使用 `startupPolicy: LeaderCreated`，让 Volcano 同时观察到一个副本中的全部 Pod。
+- 只有 Leader Pod 注册为推理 Service 和 InferencePool Endpoint。
+
+Volcano 根据 LWS 的逻辑副本身份把同一 group 中的 Leader 和 Worker 识别为一个 subgroup。即使单节点逻辑副本也使用 `size: 1` 的 LWS，使单节点与多节点共享同一生命周期、状态聚合和路由选择实现。
+
+该配置使用两个逻辑副本，每个副本跨四个节点：
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: RuntimeProfile
+metadata:
+  name: vllm-aggregated-4node-r1
+  namespace: team-a
+spec:
+  backend: vllm
+  aggregated:
+    multinode:
+      nodeCount: 4
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --port
+              - "8000"
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "4"
+              - --data-parallel-size
+              - "1"
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+        nodeSelector:
+          accelerator: h100
+---
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-70b
+  namespace: team-a
+spec:
+  modelRef:
+    kind: ClusterModel
+    name: qwen3-70b-r1
+  runtimeRef:
+    kind: RuntimeProfile
+    name: vllm-aggregated-4node-r1
+  cache:
+    mode: eager
+  replicas:
+    aggregated: 2
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+      sectionName: https
+    hostnames:
+      - qwen3-70b.example.com
+    endpointPicker:
+      strategy: prefix-cache
+```
+
+RuntimeProfile 固定 `nodeCount: 4` 和每 Pod 八张 GPU；InferenceDeployment 只把逻辑副本数设为 2。因此 Controller 得到 `2 × 4 = 8` 个 Pod、`8 × 8 = 64` 张 GPU，创建一个 `replicas: 2`、`size: 4` 的 LWS，并让两个 LWS group 加入同一个 revision-scoped PodGroup。
+
+```mermaid
+flowchart TB
+    Deployment["InferenceDeployment<br/>replicas.aggregated = 2"]
+    Runtime["RuntimeProfile<br/>aggregated.nodeCount = 4"]
+    Controller["工作负载渲染器"]
+    PodGroup["Volcano PodGroup<br/>minMember = 8<br/>subGroupSize = 4<br/>minSubGroups = 2"]
+
+    LWS["LWS aggregated<br/>replicas = 2, size = 4"]
+    Group0["逻辑副本 0"]
+    Group1["逻辑副本 1"]
+
+    Leader0["0 号 Leader"]
+    Workers0["3 个 Worker"]
+    Leader1["1 号 Leader"]
+    Workers1["3 个 Worker"]
+
+    Deployment --> Controller
+    Runtime --> Controller
+    Controller --> PodGroup
+    Controller --> LWS
+    PodGroup -.->|"2 个 subgroup"| LWS
+    LWS --> Group0
+    LWS --> Group1
+    Group0 --> Leader0
+    Group0 --> Workers0
+    Group1 --> Leader1
+    Group1 --> Workers1
+```
+
+### PodGroup {#podgroup}
+
+`minMember: 8` 表示该 revision 的全局最低 Pod 数。`subGroupPolicy` 再把每个 LWS 逻辑副本的四个 Pod 组成原子调度单元：
+
+```yaml
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: PodGroup
+metadata:
+  name: qwen3-70b
+  namespace: team-a
+spec:
+  minMember: 8
+  minResources:
+    nvidia.com/gpu: "64"
+  subGroupPolicy:
+    - name: aggregated
+      labelSelector:
+        matchLabels:
+          fusioninfer.io/role: aggregated
+      matchLabelKeys:
+        - leaderworkerset.sigs.k8s.io/group-index
+      subGroupSize: 4
+      minSubGroups: 2
+```
+
+实际 `minResources` 聚合 RuntimeProfile 中参与 Gang scheduling 的资源请求；上例只展示 GPU。`minSubGroups: 2` 与 Deployment 的 `replicas.aggregated: 2` 对应，表示两个完整的四 Pod subgroup 都满足后，PodGroup 才满足该角色的最低要求。
+
+### LeaderWorkerSet {#leaderworkerset}
+
+两个逻辑副本合并在同一个 LWS 的 `spec.replicas` 中。LWS 配置和 backend 生成的 Leader/Worker 启动差异如下：
+
+```yaml
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: qwen3-70b-aggregated
+  namespace: team-a
+spec:
+  replicas: 2
+  startupPolicy: LeaderCreated
+  rolloutStrategy:
+    type: RollingUpdate
+  leaderWorkerTemplate:
+    size: 4
+    leaderTemplate:
+      spec:
+        schedulerName: volcano
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            command:
+              - vllm
+              - serve
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "4"
+              - --data-parallel-size
+              - "1"
+              - --distributed-executor-backend
+              - mp
+              - --nnodes
+              - "4"
+              - --master-addr
+              - $(LWS_LEADER_ADDRESS)
+              - --master-port
+              - "29500"
+              - --node-rank
+              - "0"
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+    workerTemplate:
+      spec:
+        schedulerName: volcano
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            command:
+              - vllm
+              - serve
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "4"
+              - --data-parallel-size
+              - "1"
+              - --distributed-executor-backend
+              - mp
+              - --nnodes
+              - "4"
+              - --master-addr
+              - $(LWS_LEADER_ADDRESS)
+              - --master-port
+              - "29500"
+              - --node-rank
+              - $(LWS_WORKER_INDEX)
+              - --headless
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+```
+
+LWS Controller 从该对象创建两个 group，每个 group 包含一个 Leader 和三个 Worker，并注入 `LWS_LEADER_ADDRESS` 等组内发现信息：
+
+```text
+逻辑副本 0：1 个 Leader + 3 个 Worker
+逻辑副本 1：1 个 Leader + 3 个 Worker
+```
+
+Volcano 将其识别为两个四 Pod subgroup。单节点 Aggregated 部署使用相同的 PodGroup 结构，只是每个 subgroup 的 `subGroupSize` 为 1。
+
+## P/D 分离模式 {#disaggregated-pd-mode}
+
+Prefill/Decode Profile 同时包含 `prefiller` 和 `decoder`。Controller 为整个 P/D revision 生成一个 DisaggregatedSet；每个 role 映射为一个由 DisaggregatedSet 管理的 LeaderWorkerSet。两个角色可以拥有不同的 Pod 模板、逻辑副本数和 `nodeCount`，DisaggregatedSet 负责统一 revision、协调 rollout、角色状态和 Headless Service。
+
+该映射要求集群安装包含 `disaggregatedset.x-k8s.io/v1` CRD 的 LeaderWorkerSet v0.9.0 或更高版本。Controller 在启动时发现该 API；缺少时，P/D InferenceDeployment 将 `WorkloadsReady` Condition 设为 `False`，`reason` 为 `DisaggregatedSetUnavailable`。
+
+该配置规定每个 Prefiller 副本使用两个节点、每个 Decoder 副本使用四个节点。InferenceDeployment 请求一个 Prefiller 副本和两个 Decoder 副本：
+
+```yaml
+apiVersion: fusioninfer.io/v1alpha1
+kind: ClusterRuntimeProfile
+metadata:
+  name: vllm-pd-2x4-h100-r1
+spec:
+  backend: vllm
+  prefiller:
+    multinode:
+      nodeCount: 2
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --port
+              - "8000"
+              - --tensor-parallel-size
+              - "16"
+              - --data-parallel-size
+              - "1"
+              - --kv-transfer-config
+              - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+        nodeSelector:
+          accelerator: h100
+  decoder:
+    multinode:
+      nodeCount: 4
+    podTemplate:
+      spec:
+        containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.26.0
+            args:
+              - $(FUSION_MODEL_PATH)
+              - --port
+              - "8000"
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "4"
+              - --data-parallel-size
+              - "1"
+              - --kv-transfer-config
+              - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+        nodeSelector:
+          accelerator: h100
+---
+apiVersion: fusioninfer.io/v1alpha1
+kind: InferenceDeployment
+metadata:
+  name: qwen3-pd
+  namespace: team-a
+spec:
+  modelRef:
+    kind: ClusterModel
+    name: qwen3-70b-r1
+  runtimeRef:
+    kind: ClusterRuntimeProfile
+    name: vllm-pd-2x4-h100-r1
+  cache:
+    mode: eager
+  replicas:
+    prefiller: 1
+    decoder: 2
+  endpoint:
+    gatewayRef:
+      name: inference-gateway
+      namespace: gateway-system
+      sectionName: https
+    hostnames:
+      - qwen3-pd.example.com
+```
+
+`endpoint.endpointPicker` 被省略，因为 P/D 路由由 `prefiller + decoder` 角色组合推断。两个角色分别根据自己的 `nodeCount` 和 `replicas` 计算 Pod 数：
+
+```text
+prefiller Pod 数 = 1 × 2 = 2
+decoder Pod 数   = 2 × 4 = 8
+Pod 总数         = 10
+```
+
+```mermaid
+flowchart TB
+    Deployment["InferenceDeployment<br/>prefiller = 1, decoder = 2"]
+    Runtime["RuntimeProfile<br/>prefiller.nodeCount = 2<br/>decoder.nodeCount = 4"]
+    Controller["工作负载渲染器"]
+    DS["DisaggregatedSet"]
+    PodGroup["共享 Volcano PodGroup<br/>minMember = 10<br/>prefiller：2 × 1 个 subgroup<br/>decoder：4 × 2 个 subgroup"]
+
+    Prefill["Prefiller LWS<br/>replicas = 1, size = 2"]
+    Decode["Decoder LWS<br/>replicas = 2, size = 4"]
+
+    Deployment --> Controller
+    Runtime --> Controller
+    Controller --> PodGroup
+    Controller --> DS
+    DS --> Prefill
+    DS --> Decode
+    PodGroup -.->|"1 个 prefiller subgroup"| Prefill
+    PodGroup -.->|"2 个 decoder subgroup"| Decode
+```
+
+### PodGroup {#podgroup-1}
+
+P/D 的两个角色加入同一个 PodGroup，但各自拥有独立的 subgroup 规则：
+
+```yaml
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: PodGroup
+metadata:
+  name: qwen3-pd
+  namespace: team-a
+spec:
+  minMember: 10
+  subGroupPolicy:
+    - name: prefiller
+      labelSelector:
+        matchLabels:
+          fusioninfer.io/role: prefiller
+      matchLabelKeys:
+        - leaderworkerset.sigs.k8s.io/group-index
+      subGroupSize: 2
+      minSubGroups: 1
+    - name: decoder
+      labelSelector:
+        matchLabels:
+          fusioninfer.io/role: decoder
+      matchLabelKeys:
+        - leaderworkerset.sigs.k8s.io/group-index
+      subGroupSize: 4
+      minSubGroups: 2
+```
+
+该配置要求至少一个完整 Prefiller subgroup 和两个完整 Decoder subgroup。`minMember: 10` 同时要求这三个 subgroup 的十个 Pod 都进入 PodGroup 的最低调度集合。
+
+### DisaggregatedSet {#disaggregatedset}
+
+InferenceDeployment Controller 把两个 RuntimeProfile 角色编译为同一个 DisaggregatedSet。角色、副本和节点数的映射如下：
+
+```yaml
+apiVersion: disaggregatedset.x-k8s.io/v1
+kind: DisaggregatedSet
+metadata:
+  name: qwen3-pd
+  namespace: team-a
+spec:
+  roles:
+    - name: prefiller
+      spec:
+        replicas: 1
+        startupPolicy: LeaderCreated
+        leaderWorkerTemplate:
+          size: 2
+          leaderTemplate:
+            spec:
+              schedulerName: volcano
+              containers:
+                - name: engine
+                  image: vllm/vllm-openai:v0.26.0
+          workerTemplate:
+            spec:
+              schedulerName: volcano
+              containers:
+                - name: engine
+                  image: vllm/vllm-openai:v0.26.0
+
+    - name: decoder
+      spec:
+        replicas: 2
+        startupPolicy: LeaderCreated
+        leaderWorkerTemplate:
+          size: 4
+          leaderTemplate:
+            spec:
+              schedulerName: volcano
+              containers:
+                - name: engine
+                  image: vllm/vllm-openai:v0.26.0
+          workerTemplate:
+            spec:
+              schedulerName: volcano
+              containers:
+                - name: engine
+                  image: vllm/vllm-openai:v0.26.0
+```
+
+DisaggregatedSet Controller 为每个 role 生成一个 child LWS，并管理两个角色的协调 rollout 与 Headless Service。
+
+### 角色 LeaderWorkerSet {#role-leaderworkersets}
+
+DisaggregatedSet 为每个角色创建一个 LWS。其核心映射如下：
+
+```yaml
+# Prefiller
+kind: LeaderWorkerSet
+spec:
+  replicas: 1
+  startupPolicy: LeaderCreated
+  leaderWorkerTemplate:
+    size: 2
+---
+# Decoder
+kind: LeaderWorkerSet
+spec:
+  replicas: 2
+  startupPolicy: LeaderCreated
+  leaderWorkerTemplate:
+    size: 4
+```
+
+Prefiller LWS 创建一个两 Pod 逻辑副本，Decoder LWS 创建两个四 Pod 逻辑副本。角色模板中的 Leader/Worker 启动配置来自同一份 RuntimeProfile `podTemplate` 和 backend adapter。
+
+P/D 部署即使所有逻辑副本都是单节点，也使用共享 PodGroup 协调 Prefiller 与 Decoder 的最低可用集合。DisaggregatedSet 负责角色工作负载，FusionInfer 负责模型物化、共享 PodGroup 和 GAIE 路由。Endpoint Picker 和 InferencePool 只在待发布 revision 的期望角色全部就绪后切换流量。
+
+## Backend 分布式运行 {#backend-distributed-execution}
+
+RuntimeProfile 为每个推理角色提供一份 `podTemplate`。Controller 从该模板生成 Leader 和 Worker 配置，再由 backend adapter 修改 `engine` 容器的启动参数。`backend` 只选择适配器，不选择镜像、模型或并行度。
+
+### Leader 与 Worker 启动 {#leader-and-worker-startup}
+
+未设置 `multinode` 时，adapter 不添加跨节点启动参数。设置 `multinode` 后，同一份模板按角色生成两份配置：
+
+- Leader 使用 rank 0，建立分布式运行环境并启动对外提供 HTTP 服务的推理进程。
+- Worker 使用 LWS 分配的 rank 加入 Leader，不注册为 Service 或 InferencePool Endpoint。
+- 镜像、TP/PP/DP、资源、环境变量、volume 和调度约束来自原始 `podTemplate`。
+- Worker 不运行 HTTP 服务时，adapter 删除从原始模板继承的 HTTP readiness、liveness 和 startup probe。
+
+LeaderWorkerSet 提供以下组内信息：
+
+```text
+LWS_LEADER_ADDRESS   Leader Pod 的组内地址
+LWS_WORKER_INDEX     Worker 在当前 group 中的索引
+LWS_GROUP_SIZE       当前 group 的总 Pod 数
+```
+
+backend adapter 把这些值转换为对应引擎的 executor、地址、rank 和节点数参数。RuntimeProfile 不能声明 adapter 管理的 executor、地址、rank、`nnodes` 或 headless 参数；发生冲突时 Controller 拒绝生成工作负载。
+
+### vLLM {#vllm}
+
+多节点 vLLM 固定使用原生 multiprocessing executor。RuntimeProfile 只声明模型和 TP/PP/DP 等引擎参数；backend adapter 为每个 Pod 注入 `--distributed-executor-backend mp` 及组内启动参数。
+
+每个 Pod 都运行 `vllm serve`。Leader 使用：
+
+```text
+--distributed-executor-backend mp
+--nnodes 4
+--master-addr $(LWS_LEADER_ADDRESS)
+--master-port 29500
+--node-rank 0
+```
+
+Worker 使用相同的模型和并行参数，并以 headless 模式加入分布式进程组：
+
+```text
+--distributed-executor-backend mp
+--nnodes 4
+--master-addr $(LWS_LEADER_ADDRESS)
+--master-port 29500
+--node-rank $(LWS_WORKER_INDEX)
+--headless
+```
+
+Leader 对外提供 HTTP 服务，Worker 只参与分布式执行。adapter 在 Worker 启动前等待 Leader 的 multiprocessing rendezvous 端口可用。TP/PP/DP 保持 RuntimeProfile 中的原值，不根据 `nodeCount` 自动调整。
+
+### SGLang {#sglang}
+
+SGLang 使用原生分布式启动。Profile 作者声明模型参数、`--tp-size`、`--dp-size` 和每 Pod GPU 资源，adapter 为每个 Pod 增加 `dist-init-addr`、`nnodes` 和 `node-rank`。
+
+Leader 使用：
+
+```bash
+python3 -m sglang.launch_server \
+  --model-path "${FUSION_MODEL_PATH}" \
+  --tp-size 16 \
+  --dp-size 1 \
+  --dist-init-addr "${LWS_LEADER_ADDRESS}:29500" \
+  --nnodes 2 \
+  --node-rank 0
+```
+
+Worker 使用相同的引擎参数，只替换 rank：
+
+```bash
+python3 -m sglang.launch_server \
+  --model-path "${FUSION_MODEL_PATH}" \
+  --tp-size 16 \
+  --dp-size 1 \
+  --dist-init-addr "${LWS_LEADER_ADDRESS}:29500" \
+  --nnodes 2 \
+  --node-rank "${LWS_WORKER_INDEX}"
+```
+
+只有 rank 0 提供 HTTP 服务。其他 rank 运行 SGLang scheduler 和分布式计算进程，但不注册为可路由 Endpoint。
+
+### 参数所有权与校验 {#parameter-ownership-and-validation}
+
+RuntimeProfile 固定模型参数、TP/PP/DP、镜像和每 Pod 资源。backend adapter 固定 vLLM 的 multiprocessing executor，并添加随 Leader/Worker 变化的地址、rank、节点数和 headless 参数；LWS 提供 group 内的地址与索引。
+
+adapter 只接受 Operator 版本明确支持的入口形式，例如 `vllm serve` 和 `python3 -m sglang.launch_server`。它可以识别有限且有版本约束的参数，但不会解析任意 shell 脚本，也不会验证模型结构与 TP/PP/DP 的数学兼容性。无法识别的入口、重复的保留参数或不支持的参数组合都会使新工作负载保持未创建状态。
+
+## Gang Scheduling {#gang-scheduling}
+
+Aggregated 和 P/D 分离模式都使用 Volcano Gang scheduling，无论副本包含一个还是多个 Pod。
+
+Controller 在创建 standalone LWS 或 DisaggregatedSet 前创建一个 revision-scoped PodGroup。该 PodGroup 汇总所有逻辑副本：
+
+```text
+minMember =
+    Σ replicas(role) × nodesPerReplica(role)
+
+subGroupPolicy[role].subGroupSize =
+    nodesPerReplica(role)
+
+subGroupPolicy[role].minSubGroups =
+    replicas(role)
+```
+
+两个层次承担不同职责：
+
+- `minMember` 是整个 revision 的全局最低 Pod 数，并与 `minResources` 一起参与 PodGroup 准入。
+- `subGroupPolicy` 按角色和 LWS 逻辑副本形成 subgroup。
+- `subGroupSize` 保证一个逻辑副本的 Leader 和 Worker 作为原子单元调度。
+- `minSubGroups` 保证该角色至少有多少个完整逻辑副本满足调度条件。
+
+增加副本时，Controller 更新 standalone LWS 的 `spec.replicas` 或 DisaggregatedSet role 的 `spec.replicas`，并更新 PodGroup 的 `minMember` 和对应角色的 `minSubGroups`。每个角色只需要一条 `subGroupPolicy`。
+
+### PodGroup 准入语义 {#podgroup-admission-semantics}
+
+PodGroup 使用全局准入和逻辑副本原子性两个层次：
+
+- `minMember` 定义整个 revision 的最低 Pod 数。
+- `subGroupSize` 定义每个逻辑副本包含的 Pod 数。
+- `minSubGroups` 定义对应角色要求的完整逻辑副本数。
+
+两个四节点 Aggregated 副本对应 `minMember: 8`、`subGroupSize: 4` 和 `minSubGroups: 2`。每个四 Pod 逻辑副本作为一个 subgroup 调度，两个 subgroup 共同构成该 revision 的最低可用集合。
+
+共享 PodGroup 的 `minMember` 覆盖待发布 revision 的全部期望成员，因此该 revision 不支持只调度部分期望容量。资源不足时新 LWS 保持 Pending，上一 active revision 继续接收流量。该行为与“所有期望逻辑副本 Ready 后才提升 revision”的发布条件一致。
+
+Controller 把生成的 Pod `schedulerName` 设置为 Operator 配置的 Volcano scheduler。RuntimeProfile 中的 `schedulerName` 必须为空或与该值一致；冲突值会被拒绝，不进行静默覆盖。
+
+`SubGroupPolicy` 需要 Volcano v1.14 或更高版本。Operator 启动时必须发现 PodGroup CRD 是否包含 `spec.subGroupPolicy`；缺少该能力时，InferenceDeployment 将 `WorkloadsReady` Condition 设为 `False`，`reason` 为 `UnsupportedVolcanoVersion`，不能静默退化为只有 `minMember` 的调度。
+
+## 扩缩容 {#scaling}
+
+只修改 InferenceDeployment 的 `replicas` 不改变 RuntimeProfile 中的节点数、Pod 资源或引擎参数：
+
+- Aggregated 扩缩容更新 standalone LWS 的 `spec.replicas`。
+- P/D 扩缩容更新 DisaggregatedSet 对应 role 的 `spec.replicas`，DisaggregatedSet 再驱动 child LWS。
+- 扩容时同步更新 PodGroup 的 `minMember`、对应角色的 `subGroupPolicy.minSubGroups` 和 `minResources`；`subGroupSize` 不变。
+- 缩容时先停止把待删除逻辑副本的 Leader 作为可路由 Endpoint，再降低 role replicas 并收缩 PodGroup。
+- `nodeCount`、Pod 资源或 TP/PP/DP 不能通过 Deployment 扩缩；这些变化需要新 RuntimeProfile 和完整 revision rollout。
+
+部署使用动态 LoRA 时，新增逻辑副本只有在全部声明的 LoRA 加载完成后才加入可路由 Endpoint 集合；删除副本时先停止新的 Base Model 和 LoRA 请求，再卸载绑定并缩减 LWS group。预加载模式不增加独立步骤，因为 LoRA 已属于该 workload revision。
+
+Gang 扩容所需资源不足时，原有逻辑副本保持服务，Deployment 报告 `Progressing=True` 和 `WorkloadsReady=False`。Controller 不通过先删除已有副本来为新副本腾出资源。
+
+## Rollout 与失败处理 {#rollout-and-failure-handling}
+
+Model、RuntimeProfile 或缓存模式变化会产生新的 template hash。Controller 为 pending revision 创建独立的预热任务、PodGroup、standalone LWS 或 DisaggregatedSet、角色 Service 和 Endpoint Picker，不原地修改 active revision 的 Pod 模板。
+
+`loadingMode: preload` 时，解析后的 LoRA 引用、digest 和 `servedName` 参与 template hash，绑定变化采用同样的完整 rollout。`loadingMode: dynamic` 时，LoRA 集合使用独立的 binding revision；加载或卸载失败不会替换 Base Model workload，也不会影响其他已经 Ready 的 LoRA。
+
+只有以下条件同时满足时才提升新 revision：
+
+- 所需模型副本已经物化。
+- 预加载模式下，全部 LoRA 已物化并随引擎启动成功。
+- 每个逻辑副本的 Leader 和全部 Worker 都 Ready。
+- Aggregated 或 Prefill/Decode 的全部期望逻辑副本 Ready。
+- 角色 Service 已产生 Ready Endpoint。
+- Endpoint Picker 和 InferencePool 已就绪。
+
+PodGroup 无法调度、LWS 或 DisaggregatedSet 启动失败、角色协调 rollout 失败或 backend adapter 拒绝模板时，Controller 保留 active revision，通过 InferenceDeployment Conditions 报告失败原因。删除 InferenceDeployment 时同步回收其工作负载和路由资源；节点模型缓存按全局保留策略独立回收。
+
+## Status 映射 {#status-mapping}
+
+`InferenceDeployment.status.components.<role>` 按逻辑副本汇总底层状态：
+
+- `desiredReplicas` 来自 `spec.replicas.<role>`。
+- `nodesPerReplica` 来自 RuntimeProfile 的 `multinode.nodeCount`，未设置时为 1。
+- Aggregated 的 `readyReplicas` 来自 standalone LWS 的 group Ready 状态。
+- Prefiller 和 Decoder 的 `readyReplicas` 来自 DisaggregatedSet role status 与对应 child LWS；只有 group 内全部成员 Pod Ready 才计入。
+- `readyPods` 记录当前 Ready Pod 总数。
+
+用户通过 `WorkloadsReady`、`Progressing` 和 `Degraded` Conditions 获取工作负载调和结果。

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/workload-orchestration.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/design/workload-orchestration.md
@@ -38,7 +38,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --tensor-parallel-size
@@ -124,7 +124,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --port
@@ -251,7 +251,7 @@ spec:
         schedulerName: volcano
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             command:
               - vllm
               - serve
@@ -284,7 +284,7 @@ spec:
         schedulerName: volcano
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             command:
               - vllm
               - serve
@@ -343,7 +343,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --port
@@ -369,7 +369,7 @@ spec:
       spec:
         containers:
           - name: engine
-            image: vllm/vllm-openai:v0.26.0
+            image: vllm/vllm-openai:v0.27.1
             args:
               - $(FUSION_MODEL_PATH)
               - --port
@@ -502,13 +502,13 @@ spec:
               schedulerName: volcano
               containers:
                 - name: engine
-                  image: vllm/vllm-openai:v0.26.0
+                  image: vllm/vllm-openai:v0.27.1
           workerTemplate:
             spec:
               schedulerName: volcano
               containers:
                 - name: engine
-                  image: vllm/vllm-openai:v0.26.0
+                  image: vllm/vllm-openai:v0.27.1
 
     - name: decoder
       spec:
@@ -521,13 +521,13 @@ spec:
               schedulerName: volcano
               containers:
                 - name: engine
-                  image: vllm/vllm-openai:v0.26.0
+                  image: vllm/vllm-openai:v0.27.1
           workerTemplate:
             spec:
               schedulerName: volcano
               containers:
                 - name: engine
-                  image: vllm/vllm-openai:v0.26.0
+                  image: vllm/vllm-openai:v0.27.1
 ```
 
 DisaggregatedSet Controller 为每个 role 生成一个 child LWS，并管理两个角色的协调 rollout 与 Headless Service。

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/clientset-generation.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/clientset-generation.md
@@ -1,18 +1,18 @@
 ---
 sidebar_position: 1
-title: Clientset Generation
-description: Generate typed Kubernetes clientsets for FusionInfer custom resources and use them from Go.
+title: Clientset 生成
+description: 为 FusionInfer 自定义资源生成类型化 Kubernetes clientset，并在 Go 中使用它们。
 ---
 
-# Clientset Generation {#clientset-generation}
+# Clientset 生成 {#clientset-generation}
 
-FusionInfer uses `controller-runtime`'s `client.Client` for standard operations. For SharedInformers or integration with other Kubernetes components, use the generated typed clientset.
+FusionInfer 使用 `controller-runtime` 的 `client.Client` 执行常规操作。如果需要使用 SharedInformers，或与其他 Kubernetes 组件集成，请使用生成的强类型 Clientset。
 
-## Add New CRD to Clientset {#add-new-crd-to-clientset}
+## 将新 CRD 添加到 Clientset {#add-new-crd-to-clientset}
 
-To generate clientset for a new CRD type:
+要为新的 CRD 类型生成 Clientset：
 
-1. Add `+genclient` marker to your type:
+1. 为类型添加 `+genclient` 标记：
 
 ```go
 // api/core/v1alpha1/your_types.go
@@ -28,17 +28,17 @@ type YourResource struct {
 }
 ```
 
-2. Regenerate:
+2. 重新生成代码：
 
 ```bash
 ./hack/update-codegen.sh
 ```
 
-Generated code will be placed in `client-go/`.
+生成的代码将存放在 `client-go/` 中。
 
-## Usage {#usage}
+## 用法 {#usage}
 
-Use the typed clientset for CRUD operations:
+使用强类型 Clientset 执行 CRUD 操作：
 
 ```go
 import clientset "github.com/fusioninfer/fusioninfer/client-go/clientset/versioned"
@@ -46,13 +46,13 @@ import clientset "github.com/fusioninfer/fusioninfer/client-go/clientset/version
 config, _ := rest.InClusterConfig()
 client, _ := clientset.NewForConfig(config)
 
-// Get
+// 获取
 obj, _ := client.CoreV1alpha1().InferenceServices("default").Get(ctx, "name", metav1.GetOptions{})
 
-// Update status
+// 更新状态
 client.CoreV1alpha1().InferenceServices("default").UpdateStatus(ctx, obj, metav1.UpdateOptions{})
 
-// List with label selector
+// 使用标签选择器列出资源
 list, _ := client.CoreV1alpha1().InferenceServices("").List(ctx, metav1.ListOptions{
     LabelSelector: "app=inference",
 })

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro.md
@@ -1,28 +1,28 @@
 ---
 sidebar_position: 1
 slug: /intro
-description: FusionInfer is a Kubernetes-native platform for deploying, orchestrating, and routing LLM inference workloads.
+description: FusionInfer 是一个用于部署、编排和路由 LLM 推理工作负载的 Kubernetes 原生平台。
 ---
 
 # FusionInfer {#fusioninfer}
 
-A Kubernetes controller for unified LLM inference orchestration, supporting both monolithic and prefill/decode (PD) disaggregated serving topologies.
+FusionInfer 是用于统一编排 LLM 推理的 Kubernetes 控制器，同时支持一体式与 Prefill/Decode（PD）分离式服务拓扑。
 
-## Description {#description}
+## 说明 {#description}
 
-FusionInfer provides a single `InferenceService` CRD that enables:
+FusionInfer 提供统一的 `InferenceService` CRD，支持：
 
-- **Monolithic deployment**: Single-pod inference handling full request lifecycle
-- **PD disaggregated deployment**: Separate prefill and decode roles for better GPU utilization
-- **Multi-node deployment**: Distributed inference across multiple nodes using tensor parallelism
-- **Gang scheduling**: Atomic scheduling via Volcano PodGroup integration
-- **Intelligent routing**: Gateway API integration with EPP (Endpoint Picker) for request scheduling
+- **一体式部署**：由单个 Pod 执行推理并处理请求的完整生命周期
+- **PD 分离式部署**：将 Prefill 和 Decode 拆分为独立角色，提高 GPU 利用率
+- **多节点部署**：通过张量并行跨多个节点执行分布式推理
+- **Gang 调度**：集成 Volcano PodGroup，实现原子调度
+- **智能路由**：集成 Gateway API，并使用 EPP（Endpoint Picker）进行请求调度
 
-## Demo {#demo}
+## 演示 {#demo}
 
-Watch the [prefix-cache-aware routing demo](https://github.com/user-attachments/assets/1743bf67-2abd-42cd-a0f3-d7b65281f8cb).
+观看[前缀缓存感知路由演示](https://github.com/user-attachments/assets/1743bf67-2abd-42cd-a0f3-d7b65281f8cb)。
 
-## Architecture {#architecture}
+## 架构 {#architecture}
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -31,94 +31,94 @@ Watch the [prefix-cache-aware routing demo](https://github.com/user-attachments/
 └─────────────────────────────────┬───────────────────────────────┘
                                   │
                     ┌───────────────────────────────┐
-                    │   InferenceService Controller │
+                    │      InferenceService 控制器   │
                     └─────────────┬─────────────────┘
                                   │
         ┌─────────────────────────┼─────────────────────────┐
         │                         │                         │
         ▼                         ▼                         ▼
 ┌───────────────┐       ┌─────────────────┐       ┌─────────────────┐
-│   PodGroup    │       │ LeaderWorkerSet │       │  Router (EPP)   │
+│   PodGroup    │       │ LeaderWorkerSet │       │   路由器 (EPP)   │
 │  (Volcano)    │       │     (LWS)       │       │  InferencePool  │
 │               │       │                 │       │  HTTPRoute      │
 └───────────────┘       └─────────────────┘       └─────────────────┘
 ```
 
-## Getting Started {#getting-started}
+## 入门 {#getting-started}
 
-### Install Dependencies {#install-dependencies}
+### 安装依赖项 {#install-dependencies}
 
-FusionInfer requires the following components:
+FusionInfer 需要以下组件：
 
-**1. LeaderWorkerSet (LWS)** - For multi-node workload management
+**1. LeaderWorkerSet (LWS)** - 用于管理多节点工作负载
 
 ```bash
 kubectl create -f https://github.com/kubernetes-sigs/lws/releases/download/v0.7.0/manifests.yaml
 ```
 
-Reference: [LWS Installation Guide](https://lws.sigs.k8s.io/docs/installation/) | [Releases](https://github.com/kubernetes-sigs/lws/releases)
+参考：[LWS 安装指南](https://lws.sigs.k8s.io/docs/installation/) | [版本发布](https://github.com/kubernetes-sigs/lws/releases)
 
-**2. Volcano** - For gang scheduling
+**2. Volcano** - 用于 Gang 调度
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.13.1/installer/volcano-development.yaml
 ```
 
-Reference: [Volcano Installation Guide](https://volcano.sh/en/docs/installation/) | [Releases](https://github.com/volcano-sh/volcano/releases)
+参考：[Volcano 安装指南](https://volcano.sh/en/docs/installation/) | [版本发布](https://github.com/volcano-sh/volcano/releases)
 
-**3. Gateway API** - For service routing
+**3. Gateway API** - 用于服务路由
 
 ```bash
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
 ```
 
-Reference: [Gateway API Installation Guide](https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api) | [Releases](https://github.com/kubernetes-sigs/gateway-api/releases)
+参考：[Gateway API 安装指南](https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api) | [版本发布](https://github.com/kubernetes-sigs/gateway-api/releases)
 
-**4. Gateway API Inference Extension** - For intelligent inference request routing
+**4. Gateway API Inference Extension** - 用于智能路由推理请求
 
 ```bash
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.2.1/manifests.yaml
 ```
 
-Reference: [Inference Extension Docs](https://gateway-api-inference-extension.sigs.k8s.io/) | [Releases](https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases)
+参考：[Inference Extension 文档](https://gateway-api-inference-extension.sigs.k8s.io/) | [版本发布](https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases)
 
-### Install the Gateway {#install-the-gateway}
+### 安装 Gateway {#install-the-gateway}
 
-Set the Kgateway version and install the Kgateway CRDs:
+设置 Kgateway 版本并安装 Kgateway CRD：
 
 ```bash
 KGTW_VERSION=v2.1.0
 helm upgrade -i --create-namespace --namespace kgateway-system --version $KGTW_VERSION kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
 ```
 
-Install Kgateway:
+安装 Kgateway：
 
 ```bash
 helm upgrade -i --namespace kgateway-system --version $KGTW_VERSION kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --set inferenceExtension.enabled=true
 ```
 
-Deploy the Inference Gateway:
+部署 Inference Gateway：
 
 ```bash
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/config/manifests/gateway/kgateway/gateway.yaml
 ```
 
-### Quick Start (Local Development) {#quick-start-local-development}
+### 快速开始（本地开发） {#quick-start-local-development}
 
 ```bash
-# 1. Create a kind cluster (optional)
+# 1. 创建 kind 集群（可选）
 kind create cluster --name fusioninfer
 
-# 2. Install FusionInfer CRDs
+# 2. 安装 FusionInfer CRD
 make install
 
-# 3. Run the controller locally
+# 3. 在本地运行控制器
 make run
 ```
 
-## Usage Examples {#usage-examples}
+## 使用示例 {#usage-examples}
 
-### Monolithic LLM Service {#monolithic-llm-service}
+### 一体式 LLM 服务 {#monolithic-llm-service}
 
 ```yaml
 apiVersion: fusioninfer.io/v1alpha1
@@ -147,10 +147,10 @@ spec:
                   nvidia.com/gpu: "1"
 ```
 
-## Send Request {#send-request}
+## 发送请求 {#send-request}
 
 ```bash
-# You can use minikube tunnel to assign IP address to an LoadBalancer Type Service
+# 可使用 minikube tunnel 为 LoadBalancer 类型的 Service 分配 IP 地址
 GATEWAY_IP=$(kubectl get gateway inference-gateway -o jsonpath='{.status.addresses[0].value}')
 
 curl -X POST "http://${GATEWAY_IP}/v1/chat/completions" \
@@ -158,7 +158,7 @@ curl -X POST "http://${GATEWAY_IP}/v1/chat/completions" \
   -d '{
     "model": "Qwen/Qwen3-8B",
     "messages": [
-      {"role": "user", "content": "Hello, how are you?"}
+      {"role": "user", "content": "你好，最近怎么样？"}
     ]
   }'
 ```

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro.md
@@ -140,7 +140,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args: ["--model", "Qwen/Qwen3-8B"]
               resources:
                 limits:

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/deployment.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/deployment.md
@@ -33,7 +33,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args: ["--model", "Qwen/Qwen3-8B"]
               resources:
                 limits:
@@ -66,7 +66,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args: ["--model", "Qwen/Qwen3-8B", "--tensor-parallel-size", "2"]
               resources:
                 limits:

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/deployment.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/deployment.md
@@ -1,16 +1,16 @@
 ---
 sidebar_position: 1
-title: Deployment Guide
-description: Deploy FusionInfer and its dependencies on a Kubernetes cluster, then verify that the controller is ready.
+title: 部署指南
+description: 在 Kubernetes 集群中部署 FusionInfer 及其依赖项，并验证控制器已就绪。
 ---
 
-# Deployment Guide {#deployment-guide}
+# 部署指南 {#deployment-guide}
 
-This guide covers how to deploy LLM inference services using FusionInfer's `InferenceService` CRD.
+本指南介绍如何使用 FusionInfer 的 `InferenceService` CRD 部署大语言模型推理服务。
 
-## Single-Node Deployment {#single-node-deployment}
+## 单节点部署 {#single-node-deployment}
 
-Single-node deployment is the simplest way to serve LLM models. Each replica runs on a single GPU.
+单节点部署是提供大语言模型服务的最简单方式。每个副本在单个 GPU 上运行。
 
 
 ```yaml
@@ -40,9 +40,9 @@ spec:
                   nvidia.com/gpu: "1"
 ```
 
-## Multi-Node Deployment {#multi-node-deployment}
+## 多节点部署 {#multi-node-deployment}
 
-Multi-node deployment enables tensor parallelism across multiple GPUs/nodes for large models that don't fit in a single GPU's memory.
+多节点部署支持跨多个 GPU/节点进行张量并行，可用于部署无法装入单个 GPU 显存的大型模型。
 
 ```yaml
 apiVersion: fusioninfer.io/v1alpha1
@@ -75,7 +75,7 @@ spec:
                 - name: shm
                   mountPath: /dev/shm
           volumes:
-            # Increase shared memory for NCCL communication between GPUs
+            # 增大共享内存，以支持 GPU 之间的 NCCL 通信
             - name: shm
               emptyDir:
                 medium: Memory

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-theme-classic/footer.json
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-theme-classic/footer.json
@@ -1,0 +1,50 @@
+{
+  "link.title.Docs": {
+    "message": "文档",
+    "description": "The title of the footer links column with title=Docs in the footer"
+  },
+  "link.title.Resources": {
+    "message": "资源",
+    "description": "The title of the footer links column with title=Resources in the footer"
+  },
+  "link.title.Community": {
+    "message": "社区",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.item.label.Overview": {
+    "message": "概览",
+    "description": "The label of footer link with label=Overview linking to /docs/intro"
+  },
+  "link.item.label.Deployment": {
+    "message": "部署",
+    "description": "The label of footer link with label=Deployment linking to /docs/user-guide/deployment"
+  },
+  "link.item.label.Design": {
+    "message": "设计",
+    "description": "The label of footer link with label=Design linking to /docs/design/model-serving"
+  },
+  "link.item.label.Blogs": {
+    "message": "博客",
+    "description": "The label of footer link with label=Blogs linking to /blog"
+  },
+  "link.item.label.Developer Guide": {
+    "message": "开发者指南",
+    "description": "The label of footer link with label=Developer Guide linking to /docs/developer-guide/clientset-generation"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/fusioninfer/fusioninfer"
+  },
+  "link.item.label.Issues": {
+    "message": "问题",
+    "description": "The label of footer link with label=Issues linking to https://github.com/fusioninfer/fusioninfer/issues"
+  },
+  "link.item.label.Discussions": {
+    "message": "讨论",
+    "description": "The label of footer link with label=Discussions linking to https://github.com/fusioninfer/fusioninfer/discussions"
+  },
+  "copyright": {
+    "message": "版权所有 © 2026 FusionInfer。基于 Docusaurus 构建。",
+    "description": "The footer copyright"
+  }
+}

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "FusionInfer",
+    "description": "The title in the navbar"
+  },
+  "item.label.Docs": {
+    "message": "文档",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.Blogs": {
+    "message": "博客",
+    "description": "Navbar item with label Blogs"
+  }
+}

--- a/docs/fusioninfer/package-lock.json
+++ b/docs/fusioninfer/package-lock.json
@@ -26,6 +26,7 @@
         "@docusaurus/module-type-aliases": "^3.9.2",
         "@docusaurus/tsconfig": "^3.9.2",
         "@docusaurus/types": "^3.9.2",
+        "patch-package": "^8.0.1",
         "typescript": "~5.6.2"
       },
       "engines": {
@@ -6225,6 +6226,13 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -9925,6 +9933,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -11464,6 +11482,33 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -11486,6 +11531,16 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/katex": {
@@ -14827,6 +14882,78 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/path-data-parser": {
@@ -18523,6 +18650,16 @@
         "node": "^18.0.0 || >=20.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -19875,6 +20012,22 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",

--- a/docs/fusioninfer/package.json
+++ b/docs/fusioninfer/package.json
@@ -12,7 +12,9 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "check:i18n": "node scripts/check-i18n-content.mjs",
+    "typecheck": "tsc",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.2",
@@ -33,6 +35,7 @@
     "@docusaurus/module-type-aliases": "^3.9.2",
     "@docusaurus/tsconfig": "^3.9.2",
     "@docusaurus/types": "^3.9.2",
+    "patch-package": "^8.0.1",
     "typescript": "~5.6.2"
   },
   "browserslist": {

--- a/docs/fusioninfer/patches/@docusaurus+theme-classic+3.9.2.patch
+++ b/docs/fusioninfer/patches/@docusaurus+theme-classic+3.9.2.patch
@@ -1,0 +1,114 @@
+diff --git a/node_modules/@docusaurus/theme-classic/lib/theme/NavbarItem/LocaleDropdownNavbarItem/index.js b/node_modules/@docusaurus/theme-classic/lib/theme/NavbarItem/LocaleDropdownNavbarItem/index.js
+index 340753f..c8d2dc6 100644
+--- a/node_modules/@docusaurus/theme-classic/lib/theme/NavbarItem/LocaleDropdownNavbarItem/index.js
++++ b/node_modules/@docusaurus/theme-classic/lib/theme/NavbarItem/LocaleDropdownNavbarItem/index.js
+@@ -57,6 +57,21 @@ function useLocaleDropdownUtils() {
+       );
+       return `${getBaseURLForLocale(locale)}${finalSearch}${hash}`;
+     },
++    getMobileHref: (locale, url) => {
++      const usesPathnameProtocol = url.startsWith('pathname://');
++      const href = url.replace(/^pathname:\/\//, '');
++      const localeBaseUrl = getLocaleConfig(locale).baseUrl;
++      const currentBaseUrl = siteConfig.baseUrl.replace(/\/$/, '');
++      const duplicatedBaseUrl = `${localeBaseUrl}${currentBaseUrl}`;
++      const normalizedHref =
++        currentBaseUrl && href.startsWith(duplicatedBaseUrl)
++          ? `${localeBaseUrl}${href.slice(duplicatedBaseUrl.length)}`
++          : href;
++      // Let Docusaurus Link force a full-page navigation between locale builds.
++      return usesPathnameProtocol
++        ? `pathname://${normalizedHref}`
++        : normalizedHref;
++    },
+     getLabel: (locale) => {
+       return getLocaleConfig(locale).label;
+     },
+@@ -77,10 +92,12 @@ export default function LocaleDropdownNavbarItem({
+     i18n: {currentLocale, locales},
+   } = useDocusaurusContext();
+   const localeItems = locales.map((locale) => {
++    const to = utils.getURL(locale, {queryString});
+     return {
+       label: utils.getLabel(locale),
+       lang: utils.getLang(locale),
+-      to: utils.getURL(locale, {queryString}),
++      to,
++      ...(mobile && {href: utils.getMobileHref(locale, to)}),
+       target: '_self',
+       autoAddBaseUrl: false,
+       className:
+diff --git a/node_modules/@docusaurus/theme-classic/lib/theme/NavbarItem/NavbarNavLink.js b/node_modules/@docusaurus/theme-classic/lib/theme/NavbarItem/NavbarNavLink.js
+index 54045af..942e8ca 100644
+--- a/node_modules/@docusaurus/theme-classic/lib/theme/NavbarItem/NavbarNavLink.js
++++ b/node_modules/@docusaurus/theme-classic/lib/theme/NavbarItem/NavbarNavLink.js
+@@ -26,7 +26,11 @@ export default function NavbarNavLink({
+   const toUrl = useBaseUrl(to);
+   const activeBaseUrl = useBaseUrl(activeBasePath);
+   const normalizedHref = useBaseUrl(href, {forcePrependBaseUrl: true});
+-  const isExternalLink = label && href && !isInternalUrl(href);
++  const isExternalLink =
++    label &&
++    href &&
++    !href.startsWith('pathname://') &&
++    !isInternalUrl(href);
+   // Link content is set through html XOR label
+   const linkContentProps = html
+     ? {dangerouslySetInnerHTML: {__html: html}}
+diff --git a/node_modules/@docusaurus/theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx b/node_modules/@docusaurus/theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
+index 9c16b53..40453b0 100644
+--- a/node_modules/@docusaurus/theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
++++ b/node_modules/@docusaurus/theme-classic/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
+@@ -65,6 +65,21 @@ function useLocaleDropdownUtils() {
+       );
+       return `${getBaseURLForLocale(locale)}${finalSearch}${hash}`;
+     },
++    getMobileHref: (locale: string, url: string) => {
++      const usesPathnameProtocol = url.startsWith('pathname://');
++      const href = url.replace(/^pathname:\/\//, '');
++      const localeBaseUrl = getLocaleConfig(locale).baseUrl;
++      const currentBaseUrl = siteConfig.baseUrl.replace(/\/$/, '');
++      const duplicatedBaseUrl = `${localeBaseUrl}${currentBaseUrl}`;
++      const normalizedHref =
++        currentBaseUrl && href.startsWith(duplicatedBaseUrl)
++          ? `${localeBaseUrl}${href.slice(duplicatedBaseUrl.length)}`
++          : href;
++      // Let Docusaurus Link force a full-page navigation between locale builds.
++      return usesPathnameProtocol
++        ? `pathname://${normalizedHref}`
++        : normalizedHref;
++    },
+     getLabel: (locale: string) => {
+       return getLocaleConfig(locale).label;
+     },
+@@ -87,10 +102,12 @@ export default function LocaleDropdownNavbarItem({
+     i18n: {currentLocale, locales},
+   } = useDocusaurusContext();
+   const localeItems = locales.map((locale): LinkLikeNavbarItemProps => {
++    const to = utils.getURL(locale, {queryString});
+     return {
+       label: utils.getLabel(locale),
+       lang: utils.getLang(locale),
+-      to: utils.getURL(locale, {queryString}),
++      to,
++      ...(mobile && {href: utils.getMobileHref(locale, to)}),
+       target: '_self',
+       autoAddBaseUrl: false,
+       className:
+diff --git a/node_modules/@docusaurus/theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx b/node_modules/@docusaurus/theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
+index 52e198d..4a72b03 100644
+--- a/node_modules/@docusaurus/theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
++++ b/node_modules/@docusaurus/theme-classic/src/theme/NavbarItem/NavbarNavLink.tsx
+@@ -29,7 +29,11 @@ export default function NavbarNavLink({
+   const toUrl = useBaseUrl(to);
+   const activeBaseUrl = useBaseUrl(activeBasePath);
+   const normalizedHref = useBaseUrl(href, {forcePrependBaseUrl: true});
+-  const isExternalLink = label && href && !isInternalUrl(href);
++  const isExternalLink =
++    label &&
++    href &&
++    !href.startsWith('pathname://') &&
++    !isInternalUrl(href);
+ 
+   // Link content is set through html XOR label
+   const linkContentProps = html

--- a/docs/fusioninfer/patches/@easyops-cn+docusaurus-search-local+0.55.2.patch
+++ b/docs/fusioninfer/patches/@easyops-cn+docusaurus-search-local+0.55.2.patch
@@ -1,0 +1,54 @@
+diff --git a/node_modules/@easyops-cn/docusaurus-search-local/dist/client/client/theme/SearchBar/SearchBar.jsx b/node_modules/@easyops-cn/docusaurus-search-local/dist/client/client/theme/SearchBar/SearchBar.jsx
+index 14f5473..e67b9dd 100644
+--- a/node_modules/@easyops-cn/docusaurus-search-local/dist/client/client/theme/SearchBar/SearchBar.jsx
++++ b/node_modules/@easyops-cn/docusaurus-search-local/dist/client/client/theme/SearchBar/SearchBar.jsx
+@@ -51,6 +51,11 @@ const SEARCH_PARAM_HIGHLIGHT = "_highlight";
+ export default function SearchBar({ handleSearchBarToggle, }) {
+     const isBrowser = useIsBrowser();
+     const { siteConfig: { baseUrl }, i18n: { currentLocale }, } = useDocusaurusContext();
++    const searchLabel = translate({
++        id: "theme.SearchBar.label",
++        message: "Search",
++        description: "The ARIA label and placeholder for search button",
++    });
+     // It returns undefined for non-docs pages
+     const activePlugin = useActivePlugin();
+     let versionUrl = baseUrl;
+@@ -391,11 +396,7 @@ export default function SearchBar({ handleSearchBarToggle, }) {
+         })} hidden={hidden} 
+     // Manually make the search bar be LTR even if in RTL
+     dir="ltr">
+-      <input placeholder={translate({
+-            id: "theme.SearchBar.label",
+-            message: "Search",
+-            description: "The ARIA label and placeholder for search button",
+-        })} aria-label="Search" className={`navbar__search-input ${styles.searchInput}`} onMouseEnter={onInputMouseEnter} onFocus={onInputFocus} onBlur={onInputBlur} onChange={onInputChange} ref={searchBarRef} value={inputValue}/>
++      <input placeholder={searchLabel} aria-label={searchLabel} className={`navbar__search-input ${styles.searchInput}`} onMouseEnter={onInputMouseEnter} onFocus={onInputFocus} onBlur={onInputBlur} onChange={onInputChange} ref={searchBarRef} value={inputValue}/>
+       {askAi && AskAIWidgetComponent && (<AskAIWidgetComponent ref={askAIWidgetRef} {...askAi}>
+           <span hidden></span>
+         </AskAIWidgetComponent>)}
+diff --git a/node_modules/@easyops-cn/docusaurus-search-local/dist/client/client/theme/SearchPage/SearchPage.jsx b/node_modules/@easyops-cn/docusaurus-search-local/dist/client/client/theme/SearchPage/SearchPage.jsx
+index 2efb8b4..6183050 100644
+--- a/node_modules/@easyops-cn/docusaurus-search-local/dist/client/client/theme/SearchPage/SearchPage.jsx
++++ b/node_modules/@easyops-cn/docusaurus-search-local/dist/client/client/theme/SearchPage/SearchPage.jsx
+@@ -26,6 +26,11 @@ function SearchPageContent() {
+     const { siteConfig: { baseUrl }, i18n: { currentLocale }, } = useDocusaurusContext();
+     const { selectMessage } = usePluralForm();
+     const { searchValue, searchContext, searchVersion, updateSearchPath, updateSearchContext, } = useSearchQuery();
++    const searchLabel = translate({
++        id: "theme.SearchBar.label",
++        message: "Search",
++        description: "The ARIA label and placeholder for search button",
++    });
+     const [searchQuery, setSearchQuery] = useState(searchValue);
+     const [searchResults, setSearchResults] = useState();
+     const versionUrl = `${baseUrl}${searchVersion}`;
+@@ -95,7 +100,7 @@ function SearchPageContent() {
+             "col--9": Array.isArray(searchContextByPaths),
+             "col--12": !Array.isArray(searchContextByPaths),
+         })}>
+-            <input type="search" name="q" className={styles.searchQueryInput} aria-label="Search" onChange={handleSearchInputChange} value={searchQuery} autoComplete="off" autoFocus/>
++            <input type="search" name="q" className={styles.searchQueryInput} aria-label={searchLabel} onChange={handleSearchInputChange} value={searchQuery} autoComplete="off" autoFocus/>
+           </div>
+           {Array.isArray(searchContextByPaths) ? (<div className={clsx("col", "col--3", "padding-left--none", styles.searchContextColumn)}>
+               <select name="search-context" className={styles.searchContextInput} id="context-selector" value={searchContext} onChange={(e) => updateSearchContext(e.target.value)}>

--- a/docs/fusioninfer/scripts/check-i18n-content.mjs
+++ b/docs/fusioninfer/scripts/check-i18n-content.mjs
@@ -1,0 +1,497 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const siteRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const markdownExtensions = new Set(['.md', '.mdx']);
+const homepageSourcePath = 'src/pages/index.tsx';
+const homepageCatalogPath = 'i18n/zh-Hans/code.json';
+
+const contentChecks = [
+  {
+    label: 'Docs',
+    source: 'docs',
+    translation:
+      'i18n/zh-Hans/docusaurus-plugin-content-docs/current',
+  },
+  {
+    label: 'Blog',
+    source: 'blog',
+    translation: 'i18n/zh-Hans/docusaurus-plugin-content-blog',
+  },
+];
+
+const jsonCatalogPaths = [
+  homepageCatalogPath,
+  'i18n/zh-Hans/docusaurus-theme-classic/navbar.json',
+  'i18n/zh-Hans/docusaurus-theme-classic/footer.json',
+  'i18n/zh-Hans/docusaurus-plugin-content-docs/current.json',
+  'i18n/zh-Hans/docusaurus-plugin-content-blog/options.json',
+];
+
+const requiredFiles = [
+  ...jsonCatalogPaths,
+  'blog/tags.yml',
+  'i18n/zh-Hans/docusaurus-plugin-content-blog/authors.yml',
+  'i18n/zh-Hans/docusaurus-plugin-content-blog/tags.yml',
+].sort(compareStrings);
+
+const errors = [];
+const summaries = [];
+
+for (const check of contentChecks) {
+  const sourceFiles = collectMarkdownFiles(resolve(siteRoot, check.source));
+  const translatedFiles = collectMarkdownFiles(
+    resolve(siteRoot, check.translation),
+  );
+  const missing = difference(sourceFiles, translatedFiles);
+  const extra = difference(translatedFiles, sourceFiles);
+
+  if (missing.length === 0 && extra.length === 0) {
+    summaries.push(`${check.label}: ${sourceFiles.length} file(s) matched.`);
+  } else {
+    errors.push(
+      [
+        `${check.label} Markdown file-set mismatch:`,
+        ...formatList(
+          'Missing translations',
+          missing.map((relativePath) => `${check.translation}/${relativePath}`),
+        ),
+        ...formatList(
+          'Extra translations',
+          extra.map((relativePath) => `${check.translation}/${relativePath}`),
+        ),
+      ].join('\n'),
+    );
+  }
+
+  const translatedFileSet = new Set(translatedFiles);
+  for (const relativePath of sourceFiles) {
+    if (translatedFileSet.has(relativePath)) {
+      validateMarkdownPair(check, relativePath);
+    }
+  }
+}
+
+const requiredFileContents = validateRequiredFiles(requiredFiles);
+const jsonCatalogs = validateJsonCatalogs(
+  jsonCatalogPaths,
+  requiredFileContents,
+);
+validateHomepageCatalog(jsonCatalogs.get(homepageCatalogPath));
+
+if (errors.length > 0) {
+  console.error(errors.join('\n\n'));
+  process.exitCode = 1;
+} else {
+  for (const summary of summaries) {
+    console.log(summary);
+  }
+  console.log('i18n content completeness check passed.');
+}
+
+function validateMarkdownPair(check, relativePath) {
+  const sourceRelativePath = `${check.source}/${relativePath}`;
+  const translationRelativePath = `${check.translation}/${relativePath}`;
+  const sourceHeadings = readMarkdownHeadings(sourceRelativePath);
+  const translatedHeadings = readMarkdownHeadings(translationRelativePath);
+
+  if (sourceHeadings === undefined || translatedHeadings === undefined) {
+    return;
+  }
+
+  validateHeadingIds(sourceRelativePath, sourceHeadings);
+  validateHeadingIds(translationRelativePath, translatedHeadings);
+
+  const sourceIds = sourceHeadings.map((heading) => heading.id);
+  const translatedIds = translatedHeadings.map((heading) => heading.id);
+  const mismatchIndex = firstMismatchIndex(sourceIds, translatedIds);
+
+  if (mismatchIndex === -1) {
+    return;
+  }
+
+  errors.push(
+    [
+      `${check.label} heading ID sequence mismatch for ${relativePath}:`,
+      `  Source file: ${sourceRelativePath}`,
+      `  Translation file: ${translationRelativePath}`,
+      `  First mismatch at heading ${mismatchIndex + 1}:`,
+      `    Source: ${formatHeadingAt(sourceHeadings, mismatchIndex)}`,
+      `    Translation: ${formatHeadingAt(translatedHeadings, mismatchIndex)}`,
+      `  Source IDs: ${formatHeadingSequence(sourceHeadings)}`,
+      `  Translation IDs: ${formatHeadingSequence(translatedHeadings)}`,
+    ].join('\n'),
+  );
+}
+
+function readMarkdownHeadings(relativePath) {
+  let content;
+
+  try {
+    content = readFileSync(resolve(siteRoot, relativePath), 'utf8');
+  } catch (error) {
+    errors.push(
+      `${relativePath}: unable to read Markdown file: ${getErrorMessage(error)}`,
+    );
+    return undefined;
+  }
+
+  return extractMarkdownHeadings(content);
+}
+
+function extractMarkdownHeadings(content) {
+  const lines = content.replace(/^\uFEFF/, '').split(/\r?\n/);
+  const headings = [];
+  let fence;
+  let inFrontMatter = lines[0]?.trim() === '---';
+
+  for (const [index, line] of lines.entries()) {
+    if (inFrontMatter) {
+      if (index > 0 && /^(?:---|\.\.\.)[ \t]*$/.test(line)) {
+        inFrontMatter = false;
+      }
+      continue;
+    }
+
+    if (fence !== undefined) {
+      const closingFence = line.match(/^ {0,3}(`+|~+)[ \t]*$/);
+      if (
+        closingFence !== null &&
+        closingFence[1][0] === fence.marker &&
+        closingFence[1].length >= fence.length
+      ) {
+        fence = undefined;
+      }
+      continue;
+    }
+
+    const openingFence = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+    if (openingFence !== null) {
+      fence = {
+        marker: openingFence[1][0],
+        length: openingFence[1].length,
+      };
+      continue;
+    }
+
+    const heading = line.match(/^ {0,3}(#{1,6})(?:[ \t]+|$)(.*)$/);
+    if (heading === null) {
+      continue;
+    }
+
+    const body = heading[2];
+    const explicitId = body.match(
+      /(?:^|[ \t])\{#([^{}\s]+)\}[ \t]*(?:#+[ \t]*)?$/,
+    );
+    const text = body
+      .replace(
+        /(?:^|[ \t])\{#[^{}\s]+\}[ \t]*(?:#+[ \t]*)?$/,
+        '',
+      )
+      .replace(/[ \t]+#+[ \t]*$/, '')
+      .trim();
+
+    headings.push({
+      id: explicitId?.[1],
+      line: index + 1,
+      text,
+    });
+  }
+
+  return headings;
+}
+
+function validateHeadingIds(relativePath, headings) {
+  const linesById = new Map();
+
+  for (const heading of headings) {
+    if (heading.id === undefined) {
+      errors.push(
+        `${relativePath}:${heading.line}: heading ${JSON.stringify(
+          heading.text,
+        )} is missing an explicit {#id}.`,
+      );
+      continue;
+    }
+
+    const lines = linesById.get(heading.id) ?? [];
+    lines.push(heading.line);
+    linesById.set(heading.id, lines);
+  }
+
+  for (const [id, lines] of linesById) {
+    if (lines.length > 1) {
+      errors.push(
+        `${relativePath}: duplicate heading ID ${JSON.stringify(
+          id,
+        )} on lines ${lines.join(', ')}.`,
+      );
+    }
+  }
+}
+
+function firstMismatchIndex(left, right) {
+  const length = Math.max(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    if (left[index] !== right[index]) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function formatHeadingAt(headings, index) {
+  const heading = headings[index];
+  if (heading === undefined) {
+    return '(no heading)';
+  }
+  if (heading.id === undefined) {
+    return `(missing ID, line ${heading.line})`;
+  }
+  return `${JSON.stringify(heading.id)} (line ${heading.line})`;
+}
+
+function formatHeadingSequence(headings) {
+  if (headings.length === 0) {
+    return '(none)';
+  }
+  return headings
+    .map((heading) =>
+      heading.id === undefined
+        ? `<missing ID at line ${heading.line}>`
+        : heading.id,
+    )
+    .join(' -> ');
+}
+
+function validateRequiredFiles(relativePaths) {
+  const contents = new Map();
+
+  for (const relativePath of relativePaths) {
+    const absolutePath = resolve(siteRoot, relativePath);
+    if (!isFile(absolutePath)) {
+      errors.push(
+        `${relativePath}: required file is missing or is not a regular file.`,
+      );
+      continue;
+    }
+
+    let content;
+    try {
+      content = readFileSync(absolutePath, 'utf8');
+    } catch (error) {
+      errors.push(
+        `${relativePath}: unable to read required file: ${getErrorMessage(
+          error,
+        )}`,
+      );
+      continue;
+    }
+
+    if (content.trim().length === 0) {
+      errors.push(`${relativePath}: required file is empty.`);
+      continue;
+    }
+
+    contents.set(relativePath, content);
+  }
+
+  return contents;
+}
+
+function validateJsonCatalogs(relativePaths, contents) {
+  const catalogs = new Map();
+
+  for (const relativePath of [...relativePaths].sort(compareStrings)) {
+    const content = contents.get(relativePath);
+    if (content === undefined) {
+      continue;
+    }
+
+    let catalog;
+    try {
+      catalog = JSON.parse(content);
+    } catch (error) {
+      errors.push(
+        `${relativePath}: invalid JSON catalog: ${getErrorMessage(error)}`,
+      );
+      continue;
+    }
+
+    if (!isObject(catalog)) {
+      errors.push(`${relativePath}: JSON catalog must be a non-array object.`);
+      continue;
+    }
+
+    catalogs.set(relativePath, catalog);
+    const entries = Object.entries(catalog).sort(([left], [right]) =>
+      compareStrings(left, right),
+    );
+
+    if (entries.length === 0) {
+      errors.push(`${relativePath}: JSON catalog must contain entries.`);
+      continue;
+    }
+
+    for (const [id, entry] of entries) {
+      if (!isObject(entry)) {
+        errors.push(
+          `${relativePath}: catalog entry ${JSON.stringify(
+            id,
+          )} must be a message object.`,
+        );
+      } else if (
+        typeof entry.message !== 'string' ||
+        entry.message.trim().length === 0
+      ) {
+        errors.push(
+          `${relativePath}: catalog entry ${JSON.stringify(
+            id,
+          )} must have a non-empty string "message".`,
+        );
+      }
+    }
+  }
+
+  return catalogs;
+}
+
+function validateHomepageCatalog(catalog) {
+  let source;
+  try {
+    source = readFileSync(resolve(siteRoot, homepageSourcePath), 'utf8');
+  } catch (error) {
+    errors.push(
+      `${homepageSourcePath}: unable to read homepage source: ${getErrorMessage(
+        error,
+      )}`,
+    );
+    return;
+  }
+
+  if (catalog === undefined) {
+    return;
+  }
+
+  const sourceIds = extractHomepageTranslationIds(source);
+  const catalogIds = Object.keys(catalog)
+    .filter((id) => id.startsWith('homepage.'))
+    .sort(compareStrings);
+  const missing = difference(sourceIds, catalogIds);
+  const extra = difference(catalogIds, sourceIds);
+
+  if (missing.length === 0 && extra.length === 0) {
+    return;
+  }
+
+  errors.push(
+    [
+      'Homepage translation ID set mismatch:',
+      `  Source file: ${homepageSourcePath}`,
+      `  Catalog file: ${homepageCatalogPath}`,
+      ...formatList('Missing catalog entries', missing),
+      ...formatList('Extra catalog entries', extra),
+    ].join('\n'),
+  );
+}
+
+function extractHomepageTranslationIds(source) {
+  const ids = new Set();
+  const patterns = [
+    /<Translate\b[^>]*\bid\s*=\s*(?:"(homepage\.[A-Za-z0-9_.-]+)"|'(homepage\.[A-Za-z0-9_.-]+)'|\{\s*"(homepage\.[A-Za-z0-9_.-]+)"\s*\}|\{\s*'(homepage\.[A-Za-z0-9_.-]+)'\s*\})/g,
+    /\btranslate\s*\(\s*\{\s*id\s*:\s*(?:"(homepage\.[A-Za-z0-9_.-]+)"|'(homepage\.[A-Za-z0-9_.-]+)'|`(homepage\.[A-Za-z0-9_.-]+)`)/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      const id = match.slice(1).find((value) => value !== undefined);
+      if (id !== undefined) {
+        ids.add(id);
+      }
+    }
+  }
+
+  return [...ids].sort(compareStrings);
+}
+
+function collectMarkdownFiles(root) {
+  const files = [];
+
+  if (!isDirectory(root)) {
+    return files;
+  }
+
+  walk(root, '');
+  return files.sort(compareStrings);
+
+  function walk(directory, relativeDirectory) {
+    const entries = readdirSync(directory, { withFileTypes: true }).sort(
+      (left, right) => compareStrings(left.name, right.name),
+    );
+
+    for (const entry of entries) {
+      const relativePath = relativeDirectory
+        ? `${relativeDirectory}/${entry.name}`
+        : entry.name;
+      const absolutePath = resolve(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        walk(absolutePath, relativePath);
+      } else if (
+        entry.isFile() &&
+        markdownExtensions.has(extname(entry.name))
+      ) {
+        files.push(relativePath);
+      }
+    }
+  }
+}
+
+function difference(left, right) {
+  const rightSet = new Set(right);
+  return left.filter((item) => !rightSet.has(item));
+}
+
+function formatList(label, items) {
+  const lines = [`  ${label}:`];
+  if (items.length === 0) {
+    lines.push('    (none)');
+    return lines;
+  }
+
+  for (const item of items) {
+    lines.push(`    - ${item}`);
+  }
+  return lines;
+}
+
+function compareStrings(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function isObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isDirectory(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isFile(path) {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/docs/fusioninfer/sidebars.ts
+++ b/docs/fusioninfer/sidebars.ts
@@ -4,6 +4,7 @@ const sidebars: SidebarsConfig = {
   tutorialSidebar: [
     {
       type: 'category',
+      key: 'getting-started',
       label: 'Getting Started',
       items: [
         'intro',
@@ -11,6 +12,7 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      key: 'user-guide',
       label: 'User Guide',
       items: [
         'user-guide/deployment',
@@ -18,14 +20,21 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
-      label: 'Architecture',
+      key: 'design',
+      label: 'Design',
       items: [
+        'design/model-serving',
+        'design/model',
+        'design/runtime-profile',
+        'design/inference-deployment',
+        'design/workload-orchestration',
         'design/core-design',
         'design/router',
       ],
     },
     {
       type: 'category',
+      key: 'developer-guide',
       label: 'Developer Guide',
       items: [
         'developer-guide/clientset-generation',

--- a/docs/fusioninfer/src/css/custom.css
+++ b/docs/fusioninfer/src/css/custom.css
@@ -234,11 +234,6 @@ summary,
   margin-left: auto;
 }
 
-.navbar__items--right > [class*='navbarSearchContainer'],
-.navbar__search {
-  display: none;
-}
-
 .navbar-sidebar {
   background: var(--fi-page-background);
 }

--- a/docs/fusioninfer/src/pages/index.tsx
+++ b/docs/fusioninfer/src/pages/index.tsx
@@ -192,7 +192,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args: ["--model", "Qwen/Qwen3-8B"]`,
   },
   {
@@ -226,7 +226,7 @@ spec:
         spec:
           containers:
             - name: vllm-prefill
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "Qwen/Qwen3-8B"
@@ -239,7 +239,7 @@ spec:
         spec:
           containers:
             - name: vllm-decode
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args:
                 - "--model"
                 - "Qwen/Qwen3-8B"
@@ -283,7 +283,7 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.26.0
+              image: vllm/vllm-openai:v0.27.1
               args: ["--model", "Qwen/Qwen3-8B"]`,
   },
 ];

--- a/docs/fusioninfer/src/pages/index.tsx
+++ b/docs/fusioninfer/src/pages/index.tsx
@@ -17,7 +17,9 @@ import {
 } from 'react-icons/fi';
 import {FaGithub} from 'react-icons/fa6';
 import Link from '@docusaurus/Link';
+import Translate, {translate} from '@docusaurus/Translate';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import styles from './index.module.css';
@@ -54,13 +56,15 @@ function requestGitHubStars(): Promise<number> {
   return githubStarRequest;
 }
 
-function formatGitHubStars(count: number): string {
-  return new Intl.NumberFormat('en-US', {
+function formatGitHubStars(count: number, locale: string): string {
+  const formattedCount = new Intl.NumberFormat(locale, {
     notation: count >= 1000 ? 'compact' : 'standard',
     maximumFractionDigits: 1,
-  })
-    .format(count)
-    .replace('K', 'k');
+  }).format(count);
+
+  return locale.toLowerCase().startsWith('en')
+    ? formattedCount.replace('K', 'k')
+    : formattedCount;
 }
 
 type Feature = {
@@ -71,39 +75,87 @@ type Feature = {
 
 const features: Feature[] = [
   {
-    title: 'One declarative API',
-    description:
-      'Describe the complete serving topology through a single InferenceService custom resource.',
+    title: translate({
+      id: 'homepage.features.oneApi.title',
+      message: 'One declarative API',
+      description: 'Title of the declarative API homepage feature',
+    }),
+    description: translate({
+      id: 'homepage.features.oneApi.description',
+      message:
+        'Describe the complete serving topology through a single InferenceService custom resource.',
+      description: 'Description of the declarative API homepage feature',
+    }),
     icon: FiLayers,
   },
   {
-    title: 'Monolithic or disaggregated',
-    description:
-      'Run a standard worker topology or separate prefill and decode roles without changing the control plane.',
+    title: translate({
+      id: 'homepage.features.topologies.title',
+      message: 'Monolithic or disaggregated',
+      description: 'Title of the serving topologies homepage feature',
+    }),
+    description: translate({
+      id: 'homepage.features.topologies.description',
+      message:
+        'Run a standard worker topology or separate prefill and decode roles without changing the control plane.',
+      description: 'Description of the serving topologies homepage feature',
+    }),
     icon: FiShuffle,
   },
   {
-    title: 'Multi-node inference',
-    description:
-      'Coordinate distributed inference replicas with LeaderWorkerSet and explicit nodes-per-replica.',
+    title: translate({
+      id: 'homepage.features.multiNode.title',
+      message: 'Multi-node inference',
+      description: 'Title of the multi-node inference homepage feature',
+    }),
+    description: translate({
+      id: 'homepage.features.multiNode.description',
+      message:
+        'Coordinate distributed inference replicas with LeaderWorkerSet and explicit nodes-per-replica.',
+      description: 'Description of the multi-node inference homepage feature',
+    }),
     icon: FiServer,
   },
   {
-    title: 'Inference-aware routing',
-    description:
-      'Choose prefix-cache, KV-cache utilization, queue-size, LoRA affinity, or P/D routing strategies.',
+    title: translate({
+      id: 'homepage.features.routing.title',
+      message: 'Inference-aware routing',
+      description: 'Title of the inference-aware routing homepage feature',
+    }),
+    description: translate({
+      id: 'homepage.features.routing.description',
+      message:
+        'Choose prefix-cache, KV-cache utilization, queue-size, LoRA affinity, or P/D routing strategies.',
+      description: 'Description of the inference-aware routing homepage feature',
+    }),
     icon: FiGitBranch,
   },
   {
-    title: 'Gang scheduling',
-    description:
-      'Create Volcano PodGroups so the pods required by one distributed replica can be scheduled together.',
+    title: translate({
+      id: 'homepage.features.gangScheduling.title',
+      message: 'Gang scheduling',
+      description: 'Title of the gang scheduling homepage feature',
+    }),
+    description: translate({
+      id: 'homepage.features.gangScheduling.description',
+      message:
+        'Create Volcano PodGroups so the pods required by one distributed replica can be scheduled together.',
+      description: 'Description of the gang scheduling homepage feature',
+    }),
     icon: FiZap,
   },
   {
-    title: 'Gateway API native',
-    description:
-      'Generate HTTPRoute and InferencePool resources, plus the Endpoint Picker deployment and its supporting configuration.',
+    title: translate({
+      id: 'homepage.features.gatewayApi.title',
+      message: 'Gateway API native',
+      description: 'Title of the Gateway API homepage feature',
+    }),
+    description: translate({
+      id: 'homepage.features.gatewayApi.description',
+      message:
+        'Generate HTTPRoute and InferencePool resources, plus the Endpoint Picker deployment and its supporting configuration.',
+      description: 'Description of the Gateway API homepage feature',
+    }),
     icon: FiCompass,
   },
 ];
@@ -111,10 +163,22 @@ const features: Feature[] = [
 const workflows = [
   {
     id: 'worker',
-    label: 'Deploy a worker',
-    title: 'Start with one serving role',
-    description:
-      'Declare the model container and replicas. FusionInfer reconciles the Kubernetes resources around it.',
+    label: translate({
+      id: 'homepage.workflows.worker.label',
+      message: 'Deploy a worker',
+      description: 'Tab label for the single-worker deployment workflow',
+    }),
+    title: translate({
+      id: 'homepage.workflows.worker.title',
+      message: 'Start with one serving role',
+      description: 'Title of the single-worker deployment workflow',
+    }),
+    description: translate({
+      id: 'homepage.workflows.worker.description',
+      message:
+        'Declare the model container and replicas. FusionInfer reconciles the Kubernetes resources around it.',
+      description: 'Description of the single-worker deployment workflow',
+    }),
     code: `apiVersion: fusioninfer.io/v1alpha1
 kind: InferenceService
 metadata:
@@ -128,15 +192,27 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.11.0
+              image: vllm/vllm-openai:v0.26.0
               args: ["--model", "Qwen/Qwen3-8B"]`,
   },
   {
     id: 'disaggregated',
-    label: 'Split prefill / decode',
-    title: 'Scale each inference phase independently',
-    description:
-      'Use first-class prefiller and decoder roles for a P/D-disaggregated serving topology.',
+    label: translate({
+      id: 'homepage.workflows.disaggregated.label',
+      message: 'Split prefill / decode',
+      description: 'Tab label for the disaggregated serving workflow',
+    }),
+    title: translate({
+      id: 'homepage.workflows.disaggregated.title',
+      message: 'Scale each inference phase independently',
+      description: 'Title of the disaggregated serving workflow',
+    }),
+    description: translate({
+      id: 'homepage.workflows.disaggregated.description',
+      message:
+        'Use first-class prefiller and decoder roles for a P/D-disaggregated serving topology.',
+      description: 'Description of the disaggregated serving workflow',
+    }),
     code: `apiVersion: fusioninfer.io/v1alpha1
 kind: InferenceService
 metadata:
@@ -150,7 +226,7 @@ spec:
         spec:
           containers:
             - name: vllm-prefill
-              image: vllm/vllm-openai:latest
+              image: vllm/vllm-openai:v0.26.0
               args:
                 - "--model"
                 - "Qwen/Qwen3-8B"
@@ -163,7 +239,7 @@ spec:
         spec:
           containers:
             - name: vllm-decode
-              image: vllm/vllm-openai:latest
+              image: vllm/vllm-openai:v0.26.0
               args:
                 - "--model"
                 - "Qwen/Qwen3-8B"
@@ -172,10 +248,22 @@ spec:
   },
   {
     id: 'routing',
-    label: 'Route intelligently',
-    title: 'Put inference-aware routing in front',
-    description:
-      'Add a router role and select a built-in strategy while retaining access to advanced EPP configuration.',
+    label: translate({
+      id: 'homepage.workflows.routing.label',
+      message: 'Route intelligently',
+      description: 'Tab label for the inference-aware routing workflow',
+    }),
+    title: translate({
+      id: 'homepage.workflows.routing.title',
+      message: 'Put inference-aware routing in front',
+      description: 'Title of the inference-aware routing workflow',
+    }),
+    description: translate({
+      id: 'homepage.workflows.routing.description',
+      message:
+        'Add a router role and select a built-in strategy while retaining access to advanced EPP configuration.',
+      description: 'Description of the inference-aware routing workflow',
+    }),
     code: `apiVersion: fusioninfer.io/v1alpha1
 kind: InferenceService
 metadata:
@@ -195,65 +283,190 @@ spec:
         spec:
           containers:
             - name: vllm
-              image: vllm/vllm-openai:v0.11.0
+              image: vllm/vllm-openai:v0.26.0
               args: ["--model", "Qwen/Qwen3-8B"]`,
   },
 ];
 
 const useCases = [
   {
-    eyebrow: '01 / SIMPLE',
-    title: 'Monolithic serving',
-    description:
-      'Keep the full request lifecycle in one worker role when simplicity and fast iteration matter most.',
+    eyebrow: translate({
+      id: 'homepage.useCases.monolithic.eyebrow',
+      message: '01 / SIMPLE',
+      description: 'Category label for the monolithic serving use case',
+    }),
+    title: translate({
+      id: 'homepage.useCases.monolithic.title',
+      message: 'Monolithic serving',
+      description: 'Title of the monolithic serving use case',
+    }),
+    description: translate({
+      id: 'homepage.useCases.monolithic.description',
+      message:
+        'Keep the full request lifecycle in one worker role when simplicity and fast iteration matter most.',
+      description: 'Description of the monolithic serving use case',
+    }),
     icon: FiBox,
-    details: ['Worker replicas', 'Single-node friendly', 'OpenAI-compatible engines'],
+    details: [
+      translate({
+        id: 'homepage.useCases.monolithic.details.workerReplicas',
+        message: 'Worker replicas',
+        description: 'Worker replica detail for the monolithic serving use case',
+      }),
+      translate({
+        id: 'homepage.useCases.monolithic.details.singleNode',
+        message: 'Single-node friendly',
+        description: 'Single-node detail for the monolithic serving use case',
+      }),
+      translate({
+        id: 'homepage.useCases.monolithic.details.openAi',
+        message: 'OpenAI-compatible engines',
+        description: 'Engine compatibility detail for the monolithic serving use case',
+      }),
+    ],
   },
   {
-    eyebrow: '02 / SPECIALIZED',
-    title: 'Prefill / decode',
-    description:
-      'Separate prompt processing and token generation so each phase can be provisioned and scaled independently.',
+    eyebrow: translate({
+      id: 'homepage.useCases.disaggregated.eyebrow',
+      message: '02 / SPECIALIZED',
+      description: 'Category label for the prefill/decode use case',
+    }),
+    title: translate({
+      id: 'homepage.useCases.disaggregated.title',
+      message: 'Prefill / decode',
+      description: 'Title of the prefill/decode use case',
+    }),
+    description: translate({
+      id: 'homepage.useCases.disaggregated.description',
+      message:
+        'Separate prompt processing and token generation so each phase can be provisioned and scaled independently.',
+      description: 'Description of the prefill/decode use case',
+    }),
     icon: FiActivity,
-    details: ['Dedicated roles', 'Independent replica counts', 'P/D-aware routing'],
+    details: [
+      translate({
+        id: 'homepage.useCases.disaggregated.details.roles',
+        message: 'Dedicated roles',
+        description: 'Role detail for the prefill/decode use case',
+      }),
+      translate({
+        id: 'homepage.useCases.disaggregated.details.replicas',
+        message: 'Independent replica counts',
+        description: 'Replica count detail for the prefill/decode use case',
+      }),
+      translate({
+        id: 'homepage.useCases.disaggregated.details.routing',
+        message: 'P/D-aware routing',
+        description: 'Routing detail for the prefill/decode use case',
+      }),
+    ],
   },
   {
-    eyebrow: '03 / DISTRIBUTED',
-    title: 'Multi-node inference',
-    description:
-      'Run models across multiple nodes with explicit replica topology and coordinated scheduling.',
+    eyebrow: translate({
+      id: 'homepage.useCases.multiNode.eyebrow',
+      message: '03 / DISTRIBUTED',
+      description: 'Category label for the multi-node inference use case',
+    }),
+    title: translate({
+      id: 'homepage.useCases.multiNode.title',
+      message: 'Multi-node inference',
+      description: 'Title of the multi-node inference use case',
+    }),
+    description: translate({
+      id: 'homepage.useCases.multiNode.description',
+      message:
+        'Run models across multiple nodes with explicit replica topology and coordinated scheduling.',
+      description: 'Description of the multi-node inference use case',
+    }),
     icon: FiCpu,
-    details: ['LeaderWorkerSet', 'Volcano PodGroup', 'Tensor parallel workloads'],
+    details: [
+      'LeaderWorkerSet',
+      'Volcano PodGroup',
+      translate({
+        id: 'homepage.useCases.multiNode.details.tensorParallel',
+        message: 'Tensor parallel workloads',
+        description: 'Tensor parallel detail for the multi-node inference use case',
+      }),
+    ],
   },
 ];
 
 const demos = [
   {
     id: 'prefix-cache',
-    label: 'Prefix-cache routing',
-    title: 'Route shared prefixes to the right replica',
-    description:
-      'See inference-aware routing reuse prefix cache state across repeated requests.',
+    label: translate({
+      id: 'homepage.demos.prefixCache.label',
+      message: 'Prefix-cache routing',
+      description: 'Tab label for the prefix-cache routing demo',
+    }),
+    title: translate({
+      id: 'homepage.demos.prefixCache.title',
+      message: 'Route shared prefixes to the right replica',
+      description: 'Title of the prefix-cache routing demo',
+    }),
+    description: translate({
+      id: 'homepage.demos.prefixCache.description',
+      message:
+        'See inference-aware routing reuse prefix cache state across repeated requests.',
+      description: 'Description of the prefix-cache routing demo',
+    }),
     src: 'https://github.com/user-attachments/assets/1743bf67-2abd-42cd-a0f3-d7b65281f8cb',
     poster: '/img/demos/prefix-cache-routing-poster.jpg',
     steps: [
-      'Send requests that share a prompt prefix.',
-      'Observe prefix-cache-aware routing select a serving replica.',
-      'Confirm the requests reach the selected worker.',
+      translate({
+        id: 'homepage.demos.prefixCache.steps.send',
+        message: 'Send requests that share a prompt prefix.',
+        description: 'First transcript step of the prefix-cache routing demo',
+      }),
+      translate({
+        id: 'homepage.demos.prefixCache.steps.observe',
+        message: 'Observe prefix-cache-aware routing select a serving replica.',
+        description: 'Second transcript step of the prefix-cache routing demo',
+      }),
+      translate({
+        id: 'homepage.demos.prefixCache.steps.confirm',
+        message: 'Confirm the requests reach the selected worker.',
+        description: 'Third transcript step of the prefix-cache routing demo',
+      }),
     ],
   },
   {
     id: 'multi-node',
-    label: 'Multi-node inference',
-    title: 'Coordinate a distributed model replica',
-    description:
-      'See FusionInfer manage the multi-node lifecycle behind one InferenceService.',
+    label: translate({
+      id: 'homepage.demos.multiNode.label',
+      message: 'Multi-node inference',
+      description: 'Tab label for the multi-node inference demo',
+    }),
+    title: translate({
+      id: 'homepage.demos.multiNode.title',
+      message: 'Coordinate a distributed model replica',
+      description: 'Title of the multi-node inference demo',
+    }),
+    description: translate({
+      id: 'homepage.demos.multiNode.description',
+      message:
+        'See FusionInfer manage the multi-node lifecycle behind one InferenceService.',
+      description: 'Description of the multi-node inference demo',
+    }),
     src: 'https://github.com/user-attachments/assets/0c7d2126-5e71-44b7-b1ed-7ac29de7b045',
     poster: '/img/demos/multi-node-inference-poster.jpg',
     steps: [
-      'Apply an InferenceService with a multi-node replica topology.',
-      'Observe the distributed workload and coordinated scheduling resources.',
-      'Send an inference request after the replica becomes ready.',
+      translate({
+        id: 'homepage.demos.multiNode.steps.apply',
+        message: 'Apply an InferenceService with a multi-node replica topology.',
+        description: 'First transcript step of the multi-node inference demo',
+      }),
+      translate({
+        id: 'homepage.demos.multiNode.steps.observe',
+        message:
+          'Observe the distributed workload and coordinated scheduling resources.',
+        description: 'Second transcript step of the multi-node inference demo',
+      }),
+      translate({
+        id: 'homepage.demos.multiNode.steps.send',
+        message: 'Send an inference request after the replica becomes ready.',
+        description: 'Third transcript step of the multi-node inference demo',
+      }),
     ],
   },
 ];
@@ -292,6 +505,9 @@ function handleTabKeyDown(
 }
 
 function GitHubStarButton() {
+  const {
+    i18n: {currentLocale},
+  } = useDocusaurusContext();
   const [starState, setStarState] = useState<GitHubStarState>({
     status: 'loading',
   });
@@ -318,24 +534,52 @@ function GitHubStarButton() {
 
   const count =
     starState.status === 'ready'
-      ? formatGitHubStars(starState.count)
+      ? formatGitHubStars(starState.count, currentLocale)
       : starState.status === 'loading'
         ? '…'
         : '—';
   const countLabel =
     starState.status === 'ready'
-      ? `${starState.count.toLocaleString('en-US')} stars`
+      ? translate(
+          {
+            id: 'homepage.githubStars.readyLabel',
+            message: '{count} stars',
+            description: 'Accessible GitHub star count on the homepage',
+          },
+          {count: starState.count.toLocaleString(currentLocale)},
+        )
       : starState.status === 'loading'
-        ? 'Loading star count'
-        : 'Star count unavailable';
+        ? translate({
+            id: 'homepage.githubStars.loadingLabel',
+            message: 'Loading star count',
+            description: 'Accessible loading state for the GitHub star count',
+          })
+        : translate({
+            id: 'homepage.githubStars.errorLabel',
+            message: 'Star count unavailable',
+            description: 'Accessible error state for the GitHub star count',
+          });
 
   return (
     <Link
       className={styles.githubButton}
       href={GITHUB_URL}
-      aria-label={`Star FusionInfer on GitHub, ${countLabel}`}>
+      aria-label={translate(
+        {
+          id: 'homepage.githubStars.buttonAriaLabel',
+          message: 'Star FusionInfer on GitHub, {countLabel}',
+          description: 'Accessible label for the homepage GitHub star button',
+        },
+        {countLabel},
+      )}>
       <FaGithub aria-hidden="true" />
-      <span className={styles.githubLabel}>Star</span>
+      <span className={styles.githubLabel}>
+        <Translate
+          id="homepage.githubStars.buttonLabel"
+          description="Visible label for the homepage GitHub star button">
+          Star
+        </Translate>
+      </span>
       <span
         aria-busy={starState.status === 'loading'}
         aria-label={countLabel}
@@ -352,7 +596,13 @@ function HeroVisual() {
   const brandMark = useBaseUrl('/img/fusioninfer-logo.png');
 
   return (
-    <div className={styles.heroVisual} aria-label="FusionInfer architecture overview">
+    <div
+      className={styles.heroVisual}
+      aria-label={translate({
+        id: 'homepage.hero.visualAriaLabel',
+        message: 'FusionInfer architecture overview',
+        description: 'Accessible label for the homepage hero architecture visual',
+      })}>
       <div className={styles.heroGlow} aria-hidden="true" />
       <svg
         className={styles.orbitLines}
@@ -370,19 +620,43 @@ function HeroVisual() {
 
       <div className={`${styles.heroNode} ${styles.heroNodeTop}`}>
         <FiLayers aria-hidden="true" />
-        <span>One API</span>
+        <span>
+          <Translate
+            id="homepage.hero.nodes.oneApi"
+            description="Label for the API node in the homepage hero visual">
+            One API
+          </Translate>
+        </span>
       </div>
       <div className={`${styles.heroNode} ${styles.heroNodeRight}`}>
         <FiGitBranch aria-hidden="true" />
-        <span>Smart routing</span>
+        <span>
+          <Translate
+            id="homepage.hero.nodes.smartRouting"
+            description="Label for the routing node in the homepage hero visual">
+            Smart routing
+          </Translate>
+        </span>
       </div>
       <div className={`${styles.heroNode} ${styles.heroNodeBottom}`}>
         <FiServer aria-hidden="true" />
-        <span>Multi-node</span>
+        <span>
+          <Translate
+            id="homepage.hero.nodes.multiNode"
+            description="Label for the multi-node node in the homepage hero visual">
+            Multi-node
+          </Translate>
+        </span>
       </div>
       <div className={`${styles.heroNode} ${styles.heroNodeLeft}`}>
         <FiZap aria-hidden="true" />
-        <span>Scheduling</span>
+        <span>
+          <Translate
+            id="homepage.hero.nodes.scheduling"
+            description="Label for the scheduling node in the homepage hero visual">
+            Scheduling
+          </Translate>
+        </span>
       </div>
 
       <div className={styles.dragonCore}>
@@ -403,20 +677,40 @@ function Hero() {
         <div className={styles.heroGrid}>
           <div className={styles.heroCopy}>
             <Heading as="h1">
-              The Kubernetes-native platform for LLM inference.
+              <Translate
+                id="homepage.hero.title"
+                description="Primary heading on the FusionInfer homepage">
+                The Kubernetes-native platform for LLM inference.
+              </Translate>
             </Heading>
             <p>
-              Orchestrate monolithic, prefill/decode, and multi-node serving
-              through one declarative API—with intelligent routing and
-              scheduling built in.
+              <Translate
+                id="homepage.hero.description"
+                description="Primary description on the FusionInfer homepage">
+                {
+                  'Orchestrate monolithic, prefill/decode, and multi-node serving through one declarative API—with intelligent routing and scheduling built in.'
+                }
+              </Translate>
             </p>
             <GitHubStarButton />
           </div>
           <HeroVisual />
         </div>
 
-        <div className={styles.ecosystem} aria-label="FusionInfer ecosystem integrations">
-          <span>Built on the Kubernetes ecosystem</span>
+        <div
+          className={styles.ecosystem}
+          aria-label={translate({
+            id: 'homepage.hero.ecosystemAriaLabel',
+            message: 'FusionInfer ecosystem integrations',
+            description: 'Accessible label for the homepage ecosystem integrations',
+          })}>
+          <span>
+            <Translate
+              id="homepage.hero.ecosystemLabel"
+              description="Introductory label for homepage ecosystem integrations">
+              Built on the Kubernetes ecosystem
+            </Translate>
+          </span>
           <ul>
             <li>Gateway API</li>
             <li>Inference Extension</li>
@@ -435,11 +729,28 @@ function FeatureGrid() {
     <section className={styles.section}>
       <div className={styles.shell}>
         <div className={styles.sectionHeading}>
-          <span>WHY FUSIONINFER</span>
-          <Heading as="h2">One control plane across serving topologies</Heading>
+          <span>
+            <Translate
+              id="homepage.features.eyebrow"
+              description="Eyebrow label for the homepage features section">
+              WHY FUSIONINFER
+            </Translate>
+          </span>
+          <Heading as="h2">
+            <Translate
+              id="homepage.features.heading"
+              description="Heading for the homepage features section">
+              One control plane across serving topologies
+            </Translate>
+          </Heading>
           <p>
-            Keep the user-facing API compact while FusionInfer coordinates the
-            Kubernetes resources that modern inference needs.
+            <Translate
+              id="homepage.features.intro"
+              description="Introductory text for the homepage features section">
+              {
+                'Keep the user-facing API compact while FusionInfer coordinates the Kubernetes resources that modern inference needs.'
+              }
+            </Translate>
           </p>
         </div>
 
@@ -466,8 +777,20 @@ function WorkflowSection() {
     <section className={`${styles.section} ${styles.workflowSection}`}>
       <div className={styles.shell}>
         <div className={styles.sectionHeading}>
-          <span>BUILT FOR PLATFORM TEAMS</span>
-          <Heading as="h2">A declarative workflow that stays readable</Heading>
+          <span>
+            <Translate
+              id="homepage.workflows.eyebrow"
+              description="Eyebrow label for the homepage workflows section">
+              BUILT FOR PLATFORM TEAMS
+            </Translate>
+          </span>
+          <Heading as="h2">
+            <Translate
+              id="homepage.workflows.heading"
+              description="Heading for the homepage workflows section">
+              A declarative workflow that stays readable
+            </Translate>
+          </Heading>
         </div>
 
         <div className={styles.workflowGrid}>
@@ -475,7 +798,11 @@ function WorkflowSection() {
             <div
               className={styles.workflowNav}
               role="tablist"
-              aria-label="Inference workflows"
+              aria-label={translate({
+                id: 'homepage.workflows.tabListAriaLabel',
+                message: 'Inference workflows',
+                description: 'Accessible label for the homepage workflow tabs',
+              })}
               aria-orientation="vertical">
               {workflows.map((workflow) => (
                 <button
@@ -507,7 +834,12 @@ function WorkflowSection() {
               <Heading as="h3">{activeWorkflow.title}</Heading>
               <p>{activeWorkflow.description}</p>
               <Link to="/docs/user-guide/deployment">
-                Read the deployment guide <FiArrowUpRight aria-hidden="true" />
+                <Translate
+                  id="homepage.workflows.deploymentGuideCta"
+                  description="Link label for the deployment guide from the workflows section">
+                  Read the deployment guide
+                </Translate>{' '}
+                <FiArrowUpRight aria-hidden="true" />
               </Link>
             </div>
           </div>
@@ -538,23 +870,66 @@ function ArchitectureSection() {
   const outputs = [
     ['HTTPRoute', 'Gateway API'],
     ['InferencePool', 'Inference Extension'],
-    ['Endpoint Picker', 'Request scheduling'],
-    ['LeaderWorkerSet', 'Distributed replicas'],
-    ['PodGroup', 'Gang scheduling'],
+    [
+      'Endpoint Picker',
+      translate({
+        id: 'homepage.architecture.outputs.requestScheduling',
+        message: 'Request scheduling',
+        description: 'Purpose of Endpoint Picker in the architecture diagram',
+      }),
+    ],
+    [
+      'LeaderWorkerSet',
+      translate({
+        id: 'homepage.architecture.outputs.distributedReplicas',
+        message: 'Distributed replicas',
+        description: 'Purpose of LeaderWorkerSet in the architecture diagram',
+      }),
+    ],
+    [
+      'PodGroup',
+      translate({
+        id: 'homepage.architecture.outputs.gangScheduling',
+        message: 'Gang scheduling',
+        description: 'Purpose of PodGroup in the architecture diagram',
+      }),
+    ],
   ];
 
   return (
     <section className={`${styles.section} ${styles.architectureSection}`}>
       <div className={styles.shell}>
         <div className={styles.architectureIntro}>
-          <span>ARCHITECTURE</span>
-          <Heading as="h2">A compact API over production building blocks</Heading>
+          <span>
+            <Translate
+              id="homepage.architecture.eyebrow"
+              description="Eyebrow label for the homepage architecture section">
+              ARCHITECTURE
+            </Translate>
+          </span>
+          <Heading as="h2">
+            <Translate
+              id="homepage.architecture.heading"
+              description="Heading for the homepage architecture section">
+              A compact API over production building blocks
+            </Translate>
+          </Heading>
           <p>
-            FusionInfer watches one service definition and reconciles the
-            workload, scheduling, and routing resources required by each role.
+            <Translate
+              id="homepage.architecture.description"
+              description="Description of the FusionInfer architecture on the homepage">
+              {
+                'FusionInfer binds explicit Model, RuntimeProfile, and InferenceDeployment resources, then reconciles model downloading and caching, workloads, scheduling, and routing.'
+              }
+            </Translate>
           </p>
-          <Link to="/docs/design/core-design">
-            Explore the architecture <FiArrowUpRight aria-hidden="true" />
+          <Link to="/docs/design/model-serving">
+            <Translate
+              id="homepage.architecture.designCta"
+              description="Link label for the design documentation from the architecture section">
+              Explore the design
+            </Translate>{' '}
+            <FiArrowUpRight aria-hidden="true" />
           </Link>
         </div>
 
@@ -569,7 +944,13 @@ function ArchitectureSection() {
             <FiCpu aria-hidden="true" />
             <span>
               <strong>FusionInfer Controller</strong>
-              <small>reconcile desired topology</small>
+              <small>
+                <Translate
+                  id="homepage.architecture.controllerPurpose"
+                  description="Controller purpose in the homepage architecture diagram">
+                  reconcile desired topology
+                </Translate>
+              </small>
             </span>
           </div>
           <FiArrowDown className={styles.architectureArrow} aria-hidden="true" />
@@ -595,8 +976,20 @@ function UseCasesSection() {
     <section className={styles.section}>
       <div className={styles.shell}>
         <div className={styles.sectionHeading}>
-          <span>SERVING TOPOLOGIES</span>
-          <Heading as="h2">Start simple. Scale into the topology you need.</Heading>
+          <span>
+            <Translate
+              id="homepage.useCases.eyebrow"
+              description="Eyebrow label for the homepage serving use cases section">
+              SERVING TOPOLOGIES
+            </Translate>
+          </span>
+          <Heading as="h2">
+            <Translate
+              id="homepage.useCases.heading"
+              description="Heading for the homepage serving use cases section">
+              Start simple. Scale into the topology you need.
+            </Translate>
+          </Heading>
         </div>
 
         <div className={styles.useCaseGrid}>
@@ -640,10 +1033,29 @@ function DemoSection() {
       <div className={styles.shell}>
         <div className={styles.demoHeader}>
           <div>
-            <span>REAL WORKLOADS</span>
-            <Heading as="h2">See the control plane in motion</Heading>
+            <span>
+              <Translate
+                id="homepage.demos.eyebrow"
+                description="Eyebrow label for the homepage demos section">
+                REAL WORKLOADS
+              </Translate>
+            </span>
+            <Heading as="h2">
+              <Translate
+                id="homepage.demos.heading"
+                description="Heading for the homepage demos section">
+                See the control plane in motion
+              </Translate>
+            </Heading>
           </div>
-          <div className={styles.demoTabs} role="tablist" aria-label="FusionInfer demos">
+          <div
+            className={styles.demoTabs}
+            role="tablist"
+            aria-label={translate({
+              id: 'homepage.demos.tabListAriaLabel',
+              message: 'FusionInfer demos',
+              description: 'Accessible label for the homepage demo tabs',
+            })}>
             {demos.map((demo) => (
               <button
                 id={`demo-tab-${demo.id}`}
@@ -675,10 +1087,21 @@ function DemoSection() {
             <Heading as="h3">{activeDemo.title}</Heading>
             <p>{activeDemo.description}</p>
             <Link to="/docs/intro">
-              View the documentation <FiArrowUpRight aria-hidden="true" />
+              <Translate
+                id="homepage.demos.documentationCta"
+                description="Link label for documentation from the demos section">
+                View the documentation
+              </Translate>{' '}
+              <FiArrowUpRight aria-hidden="true" />
             </Link>
             <details className={styles.demoTranscript}>
-              <summary>What this demo shows</summary>
+              <summary>
+                <Translate
+                  id="homepage.demos.transcriptSummary"
+                  description="Summary label for a homepage demo transcript">
+                  What this demo shows
+                </Translate>
+              </summary>
               <ol>
                 {activeDemo.steps.map((step) => (
                   <li key={step}>{step}</li>
@@ -707,7 +1130,14 @@ function DemoSection() {
               <button
                 type="button"
                 className={styles.posterButton}
-                aria-label={`Play ${activeDemo.title}`}
+                aria-label={translate(
+                  {
+                    id: 'homepage.demos.playAriaLabel',
+                    message: 'Play {title}',
+                    description: 'Accessible label for a homepage demo play button',
+                  },
+                  {title: activeDemo.title},
+                )}
                 onClick={() => setIsPlaying(true)}>
                 <img src={activePoster} alt="" />
                 <span>
@@ -727,17 +1157,39 @@ function CommunitySection() {
     <section className={styles.communitySection}>
       <div className={styles.shell}>
         <div>
-          <span>BUILT IN THE OPEN</span>
-          <Heading as="h2">Shape the next generation of LLM serving.</Heading>
+          <span>
+            <Translate
+              id="homepage.community.eyebrow"
+              description="Eyebrow label for the homepage community section">
+              BUILT IN THE OPEN
+            </Translate>
+          </span>
+          <Heading as="h2">
+            <Translate
+              id="homepage.community.heading"
+              description="Heading for the homepage community section">
+              Shape the next generation of LLM serving.
+            </Translate>
+          </Heading>
           <p>
-            Explore the controller, read the design decisions, and help evolve
-            Kubernetes-native inference orchestration.
+            <Translate
+              id="homepage.community.description"
+              description="Description of the homepage community section">
+              {
+                'Explore the controller, read the design decisions, and help evolve Kubernetes-native inference orchestration.'
+              }
+            </Translate>
           </p>
         </div>
         <div className={styles.communityActions}>
           <GitHubStarButton />
           <Link to="/docs/intro">
-            Read Docs <FiArrowUpRight aria-hidden="true" />
+            <Translate
+              id="homepage.community.documentationCta"
+              description="Link label for documentation from the community section">
+              Read Docs
+            </Translate>{' '}
+            <FiArrowUpRight aria-hidden="true" />
           </Link>
         </div>
       </div>
@@ -748,8 +1200,17 @@ function CommunitySection() {
 export default function Home(): React.JSX.Element {
   return (
     <Layout
-      title="Kubernetes-native LLM inference platform"
-      description="FusionInfer orchestrates monolithic, prefill/decode, and multi-node LLM inference on Kubernetes.">
+      title={translate({
+        id: 'homepage.seo.title',
+        message: 'Kubernetes-native LLM inference platform',
+        description: 'SEO title for the FusionInfer homepage',
+      })}
+      description={translate({
+        id: 'homepage.seo.description',
+        message:
+          'FusionInfer orchestrates monolithic, prefill/decode, and multi-node LLM inference on Kubernetes.',
+        description: 'SEO description for the FusionInfer homepage',
+      })}>
       <main className={styles.homeMain}>
         <Hero />
         <FeatureGrid />


### PR DESCRIPTION
## Summary

Add a complete English and Simplified Chinese documentation experience while documenting the proposed Model, RuntimeProfile, InferenceDeployment, and workload-orchestration APIs.

## Key changes

- Configure Docusaurus i18n with English as the default and Simplified Chinese under `/fusioninfer/zh/`, including page-preserving desktop and mobile locale switching.
- Provide bilingual coverage for all Docs pages, the homepage, Blog, navigation, footer, sidebar, search, diagrams, and accessibility text.
- Add model-serving architecture and resource design documents with stable cross-locale heading IDs and localized edit links.
- Add bilingual local-search indexing, dependency patches for translated search/mobile locale behavior, and CI content-completeness guardrails.

## User impact

Users can browse and search the complete documentation site in English or Simplified Chinese. This PR changes documentation and website behavior only; it does not implement or alter runtime CRDs or controllers.

## Test plan

- `cd docs/fusioninfer && npm ci`
- `npm run check:i18n`
- `npm run typecheck`
- `npm run build`
- Manual: verified English and Chinese homepage, Docs, and Blog routes.
- Manual: verified desktop and mobile locale switching preserves the current page.
- Manual: verified English and Chinese search results, stable Blog tag routes, Mermaid rendering, localized metadata, and edit links.

## Notes

The GitHub Pages base URL remains `/fusioninfer/`; migration to organization-root hosting is intentionally deferred.