### PR TITLE
ci(codegen): verify generated clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run go vet
         run: go vet ./...
 
-      - name: Generate code
+      - name: Generate API and client code
         run: make generate
 
       - name: Generate manifests

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,9 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
-generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+generate: controller-gen code-generator ## Generate API helpers and client-go libraries.
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./api/..."
+	./hack/update-codegen.sh "$(CODEGEN_VERSION)"
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
@@ -197,11 +198,17 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
+# Use the same code-generator version as k8s.io/api.
+CODEGEN_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api)
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 GOLANGCI_LINT_VERSION ?= v2.3.0
+
+.PHONY: code-generator
+code-generator: ## Download the Kubernetes code-generator scripts.
+	go mod download k8s.io/code-generator@$(CODEGEN_VERSION)
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/docs/fusioninfer/docs/developer-guide/clientset-generation.md
+++ b/docs/fusioninfer/docs/developer-guide/clientset-generation.md
@@ -31,7 +31,7 @@ type YourResource struct {
 2. Regenerate:
 
 ```bash
-./hack/update-codegen.sh
+make generate
 ```
 
 Generated code will be placed in `client-go/`.

--- a/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/clientset-generation.md
+++ b/docs/fusioninfer/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/clientset-generation.md
@@ -31,7 +31,7 @@ type YourResource struct {
 2. 重新生成代码：
 
 ```bash
-./hack/update-codegen.sh
+make generate
 ```
 
 生成的代码将存放在 `client-go/` 中。

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -21,22 +21,18 @@ set -o pipefail
 cd "$(dirname "${0}")/.."
 REPO_ROOT="$(pwd)"
 
-# Get code-generator from go module cache
-CODEGEN_VERSION=$(go list -m -f '{{.Version}}' k8s.io/code-generator)
-CODEGEN_PKG=$(go env GOMODCACHE)/k8s.io/code-generator@${CODEGEN_VERSION}
+CODEGEN_VERSION="${1:?code-generator version is required}"
+CODEGEN_PKG="$(go env GOMODCACHE)/k8s.io/code-generator@${CODEGEN_VERSION}"
 
+export KUBE_CODEGEN_TAG="${CODEGEN_VERSION}"
 source "${CODEGEN_PKG}/kube_codegen.sh"
 
-# Workaround for code-generator directory resolution
-mkdir -p github.com && ln -s ../.. github.com/fusioninfer
-trap "rm -rf github.com" EXIT
-
 # Generate deepcopy, defaulter, conversion functions
-kube::codegen::gen_helpers github.com/fusioninfer/fusioninfer/api \
+kube::codegen::gen_helpers "${REPO_ROOT}/api" \
     --boilerplate "${REPO_ROOT}/hack/boilerplate.go.txt"
 
 # Generate client, listers, informers and apply configurations
-kube::codegen::gen_client github.com/fusioninfer/fusioninfer/api \
+kube::codegen::gen_client "${REPO_ROOT}/api" \
     --with-watch \
     --with-applyconfig \
     --output-dir "${REPO_ROOT}/client-go" \


### PR DESCRIPTION
## Summary

Make API code generation reproducible and ensure CI detects stale generated client libraries before resource API work begins.

## Key changes

- Make `make generate` run both `controller-gen object` and Kubernetes client generation while keeping `make manifests` independent.
- Align `code-generator` with the pinned `k8s.io/api` version and pass that version explicitly through the generation script.
- Replace the legacy package-path workaround with the local API directory expected by current `kube_codegen.sh`.
- Update the bilingual clientset guide to use the supported `make generate` entry point and clarify the CI step name.

## User impact

Developers now use one command, `make generate`, after changing FusionInfer API types. Direct invocation of `hack/update-codegen.sh` remains an internal implementation detail.

## Test plan

- `bash -n hack/update-codegen.sh`
- `make generate manifests`
- `make test`
- `cd docs/fusioninfer && npm run check:i18n && npm run typecheck && npm run build`
- Repeated generation produced no changes under `api/`, `client-go/`, or generated manifests.

## Notes

This PR adds no API resources or CRDs. `make manifests` remains a separate target.